### PR TITLE
Preferred editor fix

### DIFF
--- a/.changeset/brave-monkeys-divide.md
+++ b/.changeset/brave-monkeys-divide.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": patch
+---
+
+Always prefer dash:editor

--- a/.changeset/ten-plants-serve.md
+++ b/.changeset/ten-plants-serve.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": minor
+---
+
+Change the model for editors. Make meta optional

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,7 +13,7 @@ import '@rdfine/dash/extensions/sh/PropertyShape'
  */
 export type FocusNode = GraphPointer<BlankNode | NamedNode>
 export type { Component, SingleEditorComponent, MultiEditorComponent, RenderComponent, Lazy } from './models/components'
-export type { SingleEditor, MultiEditor } from './models/editors'
+export type { Editor, SingleEditor, MultiEditor } from './models/editors'
 
 /**
  * @ignore

--- a/packages/core/models/editors/index.ts
+++ b/packages/core/models/editors/index.ts
@@ -12,28 +12,26 @@ import { decorate } from './reducers/decorate'
 import { matchSingleEditors, matchMultiEditors } from './lib/match'
 import { loadDash } from './effects'
 
-// todo: re-export from main module
-export interface EditorMatcher {
+interface EditorBase {
   term: NamedNode
+  meta?: Partial<Rdfs.Resource>
 }
 
-export interface MultiEditor extends EditorMatcher {
+export interface MultiEditor extends EditorBase {
   match: (shape: PropertyShape) => number | null
 }
 
-export interface SingleEditor<T extends Term = Term> extends EditorMatcher {
+export interface SingleEditor<T extends Term = Term> extends EditorBase {
   match: (shape: PropertyShape, value: GraphPointer<T>) => number | null
 }
 
-export interface MatcherDecorator<T extends Term = Term> extends EditorMatcher {
+export interface MatcherDecorator<T extends Term = Term> extends EditorBase {
   decorate<TEditor extends SingleEditor<T> | MultiEditor>(matcher: TEditor): TEditor['match']
 }
 
-export type Editor<T extends EditorMatcher = SingleEditor | MultiEditor> = T & {
-  meta: Partial<Rdfs.Resource>
-}
+export type Editor = SingleEditor | MultiEditor
 
-export interface SingleEditorMatch extends Omit<Editor<SingleEditor>, 'match'> {
+export interface SingleEditorMatch extends Omit<SingleEditor, 'match'> {
   score: number | null
 }
 
@@ -41,9 +39,9 @@ type EditorMap<T> = Record<string, T | undefined>
 
 export interface EditorsState {
   metadata: AnyPointer
-  allEditors: EditorMap<Editor<EditorMatcher>>
-  singleEditors: EditorMap<Editor<SingleEditor>>
-  multiEditors: EditorMap<Editor<MultiEditor>>
+  allEditors: EditorMap<Editor>
+  singleEditors: EditorMap<SingleEditor>
+  multiEditors: EditorMap<MultiEditor>
   matchSingleEditors: typeof matchSingleEditors
   matchMultiEditors: typeof matchMultiEditors
   decorators: EditorMap<MatcherDecorator[]>

--- a/packages/core/models/editors/lib/match.ts
+++ b/packages/core/models/editors/lib/match.ts
@@ -1,7 +1,7 @@
 import type { PropertyShape } from '@rdfine/shacl'
 import type { GraphPointer } from 'clownface'
 import { xsd } from '@tpluscode/rdf-ns-builders'
-import type { EditorsState, SingleEditor, SingleEditorMatch, Editor, MultiEditor } from '../index'
+import type { EditorsState, SingleEditor, SingleEditorMatch, MultiEditor } from '../index'
 
 function toDefined<T>(arr: T[], next: T | undefined): T[] {
   if (!next) {
@@ -44,7 +44,7 @@ function valuePlaceholder(shape: PropertyShape): GraphPointer {
 }
 
 export function matchSingleEditors(this: EditorsState, { shape, ...rest }: { shape: PropertyShape; object?: GraphPointer }): SingleEditorMatch[] {
-  const singleEditors = Object.values(this.singleEditors).reduce<Editor<SingleEditor>[]>(toDefined, [])
+  const singleEditors = Object.values(this.singleEditors).reduce<SingleEditor[]>(toDefined, [])
 
   const object = rest.object || valuePlaceholder(shape)
 
@@ -53,8 +53,8 @@ export function matchSingleEditors(this: EditorsState, { shape, ...rest }: { sha
     .sort(byScore)
 }
 
-export function matchMultiEditors(this: EditorsState, { shape }: { shape: PropertyShape }): Editor<MultiEditor>[] {
-  const multiEditors = Object.values(this.multiEditors).reduce<Editor<MultiEditor>[]>(toDefined, [])
+export function matchMultiEditors(this: EditorsState, { shape }: { shape: PropertyShape }): MultiEditor[] {
+  const multiEditors = Object.values(this.multiEditors).reduce<MultiEditor[]>(toDefined, [])
 
   return multiEditors
     .map(editor => ({ editor, score: editor.match(shape) }))

--- a/packages/core/models/editors/reducers/addMetadata.ts
+++ b/packages/core/models/editors/reducers/addMetadata.ts
@@ -1,7 +1,7 @@
 import { DatasetCore, Quad } from 'rdf-js'
 import * as RDF from '@rdf-esm/dataset'
 import cf, { AnyPointer } from 'clownface'
-import type { Editor, EditorMatcher, EditorsState } from '../index'
+import type { Editor, EditorsState } from '../index'
 import { EditorMeta } from '../lib/EditorMeta'
 
 type AllEditors = EditorsState['allEditors']
@@ -9,7 +9,7 @@ type MultiEditors = EditorsState['multiEditors']
 type SingleEditors = EditorsState['singleEditors']
 
 function updateMeta<T>(metadata: AnyPointer) {
-  return (previousValue: T, [key, editor]: [string, Editor<EditorMatcher> | undefined]): T => {
+  return (previousValue: T, [key, editor]: [string, Editor | undefined]): T => {
     if (!editor) {
       return previousValue
     }

--- a/packages/core/models/forms/lib/stateBuilder.ts
+++ b/packages/core/models/forms/lib/stateBuilder.ts
@@ -25,12 +25,12 @@ export function initialiseObjectState({ shape, editors, shouldEnableEditorChoice
 
     const preferredEditorId = shape.editor?.id
     if (preferredEditorId?.termType === 'NamedNode') {
-      const preferredEditor = Object.values(editors.singleEditors).find(e => e?.term.equals(preferredEditorId))
-      selectedEditor = preferredEditorId
-      if (preferredEditor) {
-        matchedEditors.splice(matchedEditors.findIndex(e => e.term.equals(preferredEditor.term)), 1)
-        matchedEditors = [{ ...preferredEditor, score: 100 }, ...matchedEditors]
+      const preferredEditor = Object.values(editors.singleEditors).find(e => e?.term.equals(preferredEditorId)) || {
+        term: preferredEditorId,
       }
+      selectedEditor = preferredEditorId
+      matchedEditors.splice(matchedEditors.findIndex(e => e.term.equals(preferredEditor.term)), 1)
+      matchedEditors = [{ ...preferredEditor, score: 100 }, ...matchedEditors]
     } else {
       selectedEditor = matchedEditors[0]?.term
     }

--- a/packages/core/test/models/editors/lib/match.test.ts
+++ b/packages/core/test/models/editors/lib/match.test.ts
@@ -4,7 +4,7 @@ import { dash, schema } from '@tpluscode/rdf-ns-builders'
 import { NamedNode } from 'rdf-js'
 import { expect } from 'chai'
 import { testStore } from '../../forms/util'
-import { Editor, EditorsState, SingleEditor, MultiEditor } from '../../../../models/editors'
+import { Editor, EditorsState, MultiEditor } from '../../../../models/editors'
 import { matchSingleEditors, matchMultiEditors } from '../../../../models/editors/lib/match'
 import { propertyShape } from '../../../util'
 
@@ -18,7 +18,7 @@ describe('models/editors/lib/match', () => {
   })
 
   describe('matchSingleEditors', () => {
-    function singleEditors(...values: [NamedNode, Editor<SingleEditor>['match']][]): void {
+    function singleEditors(...values: [NamedNode, Editor['match']][]): void {
       editors.singleEditors = values.reduce((map, [term, match]) => ({
         ...map,
         [term.value]: {
@@ -96,7 +96,7 @@ describe('models/editors/lib/match', () => {
   })
 
   describe('matchMultiEditors', () => {
-    function multiEditors(...values: [NamedNode, Editor<MultiEditor>['match']][]): void {
+    function multiEditors(...values: [NamedNode, MultiEditor['match']][]): void {
       editors.multiEditors = values.reduce((map, [term, match]) => ({
         ...map,
         [term.value]: {

--- a/packages/core/test/models/editors/reducers/addMetadata.test.ts
+++ b/packages/core/test/models/editors/reducers/addMetadata.test.ts
@@ -50,9 +50,9 @@ describe('core/models/editors/reducers/addMetadata', () => {
     const after = addMetadata(before, dataset)
 
     // expect
-    expect(after.allEditors[ex.Foo.value]?.meta.label).to.eq('Foo editor')
-    expect(after.allEditors[ex.Bar.value]?.meta.label).to.eq('Bar editor')
-    expect(after.singleEditors[ex.Foo.value]?.meta.label).to.eq('Foo editor')
-    expect(after.singleEditors[ex.Bar.value]?.meta.label).to.eq('Bar editor')
+    expect(after.allEditors[ex.Foo.value]?.meta?.label).to.eq('Foo editor')
+    expect(after.allEditors[ex.Bar.value]?.meta?.label).to.eq('Bar editor')
+    expect(after.singleEditors[ex.Foo.value]?.meta?.label).to.eq('Foo editor')
+    expect(after.singleEditors[ex.Bar.value]?.meta?.label).to.eq('Bar editor')
   })
 })

--- a/packages/core/test/models/editors/util.ts
+++ b/packages/core/test/models/editors/util.ts
@@ -3,7 +3,7 @@ import $rdf from 'rdf-ext'
 import clownface from 'clownface'
 import * as sinon from 'sinon'
 import { matchMultiEditors, matchSingleEditors } from 'packages/core/models/editors/lib/match'
-import { EditorsState, MultiEditor, SingleEditor, MatcherDecorator, EditorMatcher } from '../../../models/editors/index'
+import { EditorsState, MultiEditor, SingleEditor, MatcherDecorator, Editor } from '../../../models/editors/index'
 import { RecursivePartial } from '../forms/util'
 
 interface Initializer {
@@ -15,7 +15,7 @@ interface Initializer {
   matchMultiEditors?: (...args: Parameters<typeof matchMultiEditors>) => RecursivePartial<ReturnType<typeof matchMultiEditors>>
 }
 
-function mapEditors<T extends EditorMatcher>(editors: Record<string, T>, editor: T) {
+function mapEditors<T extends Editor>(editors: Record<string, T>, editor: T) {
   return {
     ...editors,
     [editor.term.value]: editor,

--- a/packages/core/test/models/forms/lib/stateBuilder.test.ts
+++ b/packages/core/test/models/forms/lib/stateBuilder.test.ts
@@ -398,5 +398,28 @@ describe('core/models/forms/lib/stateBuilder', () => {
       // then
       expect(state.editorSwitchDisabled).to.be.true
     })
+
+    it('set preferred editor first, even if not found in editors model', () => {
+      // given
+      const shapeGraph = cf({ dataset: $rdf.dataset() })
+      const dataGraph = cf({ dataset: $rdf.dataset() }).literal(5)
+      const shape = propertyShape(shapeGraph.blankNode(), {
+        path: ex.foo,
+        editor: dash.FooEditor,
+      })
+      const context = {
+        shape,
+        editors: store.getState().editors,
+        shouldEnableEditorChoice() {
+          return true
+        },
+      }
+
+      // when
+      const state = initialiseObjectState(context, undefined)(dataGraph.literal(5))
+
+      // then
+      expect(state.editors[0].term).to.deep.eq(dash.FooEditor)
+    })
   })
 })

--- a/packages/wc-material/elements/mwc-editor-toggle.ts
+++ b/packages/wc-material/elements/mwc-editor-toggle.ts
@@ -34,7 +34,7 @@ export class MwcEditorToggle extends SelectableMenuMixin(LitElement) {
 
   __renderEditorSelector(choice: SingleEditorMatch) {
     return this.createItem({
-      text: choice.meta.label || choice.term.value,
+      text: choice.meta?.label || choice.term.value,
       selected: choice.term.equals(this.selected),
       '@click': this.__dispatchEditorSelected(choice),
     })

--- a/packages/wc/DefaultRenderer.ts
+++ b/packages/wc/DefaultRenderer.ts
@@ -76,7 +76,7 @@ export const DefaultRenderer: Renderer = {
             }
             const component = components.components[editor.value]
             if (!component) {
-              return html`No component found for ${editors.allEditors[editor.value]?.meta.label || editor.value}`
+              return html`No component found for ${editors.allEditors[editor.value]?.meta?.label || editor.value}`
             }
 
             if (!component.render) {
@@ -152,7 +152,7 @@ export const DefaultRenderer: Renderer = {
               }
               const component = components.components[editor.value]
               if (!component) {
-                return html`No component found for ${editors.allEditors[editor.value]?.meta.label || editor.value}`
+                return html`No component found for ${editors.allEditors[editor.value]?.meta?.label || editor.value}`
               }
 
               if (!component.render) {


### PR DESCRIPTION
This PR fixes a problem where the `dash:editor` gets replaced by another editor when the object is set to `sh:default` and there is no metadata about that editor