### PR TITLE
Build state objects describing logical constraints

### DIFF
--- a/.changeset/hot-cups-dream.md
+++ b/.changeset/hot-cups-dream.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": patch
+---
+
+State actions to show and hide properties

--- a/.changeset/tricky-snakes-peel.md
+++ b/.changeset/tricky-snakes-peel.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": patch
+---
+
+Adds links from property state to originting logical constraints

--- a/.changeset/tricky-snakes-peel.md
+++ b/.changeset/tricky-snakes-peel.md
@@ -2,4 +2,4 @@
 "@hydrofoil/shaperone-core": patch
 ---
 
-Adds links from property state to originting logical constraints
+Add logical constraints state to focus node state

--- a/packages/core/models/forms/index.ts
+++ b/packages/core/models/forms/index.ts
@@ -1,7 +1,8 @@
 import { createModel } from '@captaincodeman/rdx'
 import { NamedNode } from 'rdf-js'
-import type { NodeShape, PropertyGroup, PropertyShape } from '@rdfine/shacl'
+import type { NodeShape, PropertyGroup, PropertyShape, Shape } from '@rdfine/shacl'
 import { GraphPointer } from 'clownface'
+import type { sh } from '@tpluscode/rdf-ns-builders'
 import effects from './effects'
 import { addFormField } from './reducers/addFormField'
 import { popFocusNode } from './reducers/popFocusNode'
@@ -14,6 +15,7 @@ import * as objects from './reducers/updateObject'
 import * as connection from './reducers/connection'
 import * as editors from './reducers/editors'
 import * as multiEditors from './reducers/multiEditors'
+import * as properties from './reducers/properties'
 import { FocusNode } from '../../index'
 import type { MultiEditor, SingleEditorMatch } from '../editors'
 import { createFocusNodeState } from './reducers/replaceFocusNodes'
@@ -37,6 +39,18 @@ export interface ShouldEnableEditorChoice {
   (params?: { object?: GraphPointer }): boolean
 }
 
+export interface LogicalConstraint<Type extends NamedNode = typeof sh.AndConstraintComponent | typeof sh.OrConstraintComponent | typeof sh.XoneConstraintComponent> {
+  term: GraphPointer
+  shapes: Shape[]
+  component: Type
+}
+
+export interface LogicalConstraints {
+  and: LogicalConstraint<typeof sh.AndConstraintComponent>[]
+  or: LogicalConstraint<typeof sh.OrConstraintComponent>[]
+  xone: LogicalConstraint<typeof sh.XoneConstraintComponent>[]
+}
+
 export interface PropertyState {
   shape: PropertyShape
   name: string
@@ -49,6 +63,7 @@ export interface PropertyState {
   datatype?: NamedNode
   hidden: boolean
 }
+
 export interface PropertyGroupState {
   group: PropertyGroup | undefined
   order: number
@@ -61,6 +76,7 @@ export interface FocusNodeState {
   shapes: NodeShape[]
   properties: PropertyState[]
   groups: PropertyGroupState[]
+  logicalConstraints: LogicalConstraints
 }
 
 export interface FormSettings {
@@ -89,6 +105,7 @@ const reducers = {
   ...editors,
   ...multiEditors,
   createFocusNodeState,
+  ...properties,
 }
 
 export const forms = createModel({

--- a/packages/core/models/forms/lib/property.ts
+++ b/packages/core/models/forms/lib/property.ts
@@ -1,6 +1,10 @@
 import type { PropertyShape, Shape } from '@rdfine/shacl'
 import { sh } from '@tpluscode/rdf-ns-builders'
 import { fromPointer } from '@rdfine/shacl/lib/PropertyShape'
+import { fromPointer as createShape } from '@rdfine/shacl/lib/Shape'
+import { BlankNode, NamedNode } from 'rdf-js'
+import type { GraphPointer } from 'clownface'
+import type { LogicalConstraints } from '../index'
 
 export function canAddObject(property: PropertyShape, length: number): boolean {
   return length < (property.maxCount || Number.POSITIVE_INFINITY)
@@ -10,23 +14,72 @@ export function canRemoveObject(property: PropertyShape, length: number): boolea
   return length > (property.minCount || 0)
 }
 
-function isPropertyShape(shape: Shape): shape is PropertyShape {
-  return shape.pointer.out(sh.path).terms.length > 0
+function isPropertyShape(shape: GraphPointer): boolean {
+  return shape.out(sh.path).terms.length > 0
 }
 
-function getProperties(shape: Shape): PropertyShape[] {
-  if (isPropertyShape(shape)) {
-    return [fromPointer(shape.pointer)]
+function isResourceNode(ptr: GraphPointer): ptr is GraphPointer<BlankNode> | GraphPointer<NamedNode> {
+  return ptr.term.termType === 'BlankNode' || ptr.term.termType === 'NamedNode'
+}
+
+function getProperties(constraint: GraphPointer): PropertyShape[] {
+  const list = constraint.list()
+  if (!list) {
+    return []
   }
 
-  return shape.property
+  return [...list].reduce<PropertyShape[]>((shapes, shape) => {
+    if (!isResourceNode(shape)) {
+      return shapes
+    }
+
+    if (isPropertyShape(shape)) {
+      return [...shapes, fromPointer(shape)]
+    }
+
+    return [...shapes, ...shape.out(sh.property).filter(isResourceNode).map((ptr: any) => fromPointer(ptr))]
+  }, [])
 }
 
-export function combineProperties(shape: Shape): PropertyShape[] {
-  return [
-    shape,
-    ...shape.and,
-    ...shape.or,
-    ...shape.xone,
-  ].flatMap(getProperties)
+export function combineProperties(shape: Shape): { properties: PropertyShape[]; logicalConstraints: LogicalConstraints } {
+  let properties: PropertyShape[] = shape.property
+  const logicalConstraints: LogicalConstraints = { xone: [], and: [], or: [] }
+
+  for (const constraint of shape.pointer.out(sh.and).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.and.push({
+        term: constraint,
+        component: sh.AndConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  for (const constraint of shape.pointer.out(sh.or).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.or.push({
+        term: constraint,
+        component: sh.OrConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  for (const constraint of shape.pointer.out(sh.xone).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.xone.push({
+        term: constraint,
+        component: sh.XoneConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  return { properties, logicalConstraints }
 }

--- a/packages/core/models/forms/reducers/properties.ts
+++ b/packages/core/models/forms/reducers/properties.ts
@@ -1,0 +1,28 @@
+import produce from 'immer'
+import type { Shape } from '@rdfine/shacl'
+import { BaseParams, formStateReducer } from '../../index'
+import type { FormState } from '../index'
+import { FocusNode } from '../../../index'
+
+export interface ToggleParams extends BaseParams {
+  focusNode: FocusNode
+  shape: Shape
+}
+
+export const showProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
+  const focusNodeState = state.focusNodes[focusNode.value]
+  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+
+  for (const propertyState of propertyStates) {
+    propertyState.hidden = false
+  }
+}))
+
+export const hideProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
+  const focusNodeState = state.focusNodes[focusNode.value]
+  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+
+  for (const propertyState of propertyStates) {
+    propertyState.hidden = true
+  }
+}))

--- a/packages/core/renderer.ts
+++ b/packages/core/renderer.ts
@@ -3,7 +3,7 @@
  * @module @hydrofoil/shaperone-core/renderer
  */
 
-import type { NodeShape } from '@rdfine/shacl'
+import type { NodeShape, Shape } from '@rdfine/shacl'
 import { PropertyGroup } from '@rdfine/shacl'
 import { NamedNode, Term } from 'rdf-js'
 import type { GraphPointer } from 'clownface'
@@ -84,6 +84,9 @@ export interface FocusNodeActions {
    * @param shape
    */
   selectShape (shape: NodeShape): void
+
+  hideProperty (shape: Shape): void
+  showProperty (shape: Shape): void
 }
 
 /**

--- a/packages/core/test/models/forms/lib/stateBuilder.test.ts
+++ b/packages/core/test/models/forms/lib/stateBuilder.test.ts
@@ -375,6 +375,78 @@ describe('core/models/forms/lib/stateBuilder', () => {
       expect(state.properties).to.have.length(6)
     })
 
+    it('adds logical constraint groups to focus node state', () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const focusNode = graph.node(ex.Person)
+      const shape = fromPointer(graph.blankNode(), {
+        or: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+        and: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+        xone: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+      })
+
+      // when
+      const state = initialiseFocusNode({
+        focusNode,
+        editors: store.getState().editors,
+        shape,
+        shapes: [],
+        shouldEnableEditorChoice: () => true,
+      }, undefined)
+
+      // then
+      expect(state.logicalConstraints.or).to.have.length(1)
+      expect(state.logicalConstraints.and).to.have.length(1)
+      expect(state.logicalConstraints.xone).to.have.length(1)
+    })
+
+    it('provides pointers to logical constraints a property may be part of', () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const focusNode = graph.node(ex.Person)
+      const shape = fromPointer(graph.blankNode(), {
+        or: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+      })
+
+      // when
+      const state = initialiseFocusNode({
+        focusNode,
+        editors: store.getState().editors,
+        shape,
+        shapes: [],
+        shouldEnableEditorChoice: () => true,
+      }, undefined)
+
+      // then
+      const logicalConstraint = state.logicalConstraints.or[0]
+      expect(logicalConstraint.term.term).to.deep.equal(shape.pointer.out(sh.or).term)
+      expect(logicalConstraint.component).to.deep.equal(sh.OrConstraintComponent)
+    })
+
     it('combines all property shapes from logical constraints, defined without wrapping node shape', () => {
       // given
       const graph = cf({ dataset: $rdf.dataset() })

--- a/packages/testing/renderer.ts
+++ b/packages/testing/renderer.ts
@@ -56,6 +56,8 @@ export const focusNodeRenderer = (arg: TestFocusNode): sinon.SinonStubbedInstanc
       ...form.actions,
       selectGroup: sinon.spy(),
       selectShape: sinon.spy(),
+      hideProperty: sinon.spy(),
+      showProperty: sinon.spy(),
     },
   })
 }

--- a/packages/wc/renderer/focusNode.ts
+++ b/packages/wc/renderer/focusNode.ts
@@ -1,6 +1,6 @@
 import { FormRenderer, FocusNodeRenderer } from '@hydrofoil/shaperone-core/renderer'
 import { TemplateResult } from 'lit-element'
-import { NodeShape, PropertyGroup } from '@rdfine/shacl'
+import { NodeShape, PropertyGroup, Shape } from '@rdfine/shacl'
 import { renderGroup } from './group'
 
 export const renderFocusNode: FormRenderer['renderFocusNode'] = function ({ focusNode, shape }): TemplateResult {
@@ -21,6 +21,8 @@ export const renderFocusNode: FormRenderer['renderFocusNode'] = function ({ focu
     ...this.actions,
     selectGroup: (group: PropertyGroup | undefined) => dispatch.forms.selectGroup({ form, focusNode, group }),
     selectShape: (shape: NodeShape) => dispatch.forms.selectShape({ form, focusNode, shape }),
+    hideProperty: (shape: Shape) => dispatch.forms.hideProperty({ form, focusNode, shape }),
+    showProperty: (shape: Shape) => dispatch.forms.showProperty({ form, focusNode, shape }),
   }
 
   const context: FocusNodeRenderer = {


### PR DESCRIPTION
Without being too, specific, this PR introduces new properties of `FocusNodeState` which represent Node Shape logical constraints

Also, adds state actions to show/hide individual properties