### PR TITLE
Build state objects describing logical constraints

### DIFF
--- a/.changeset/fast-books-pretend.md
+++ b/.changeset/fast-books-pretend.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-wc": patch
+---
+
+Utility to create template decorators (#125)

--- a/.changeset/hot-cups-dream.md
+++ b/.changeset/hot-cups-dream.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": patch
+---
+
+State actions to show and hide properties

--- a/.changeset/seven-mails-sniff.md
+++ b/.changeset/seven-mails-sniff.md
@@ -1,0 +1,6 @@
+---
+"@hydrofoil/shaperone-playground-examples": patch
+"@hydrofoil/shaperone-playground": patch
+---
+
+Example sh:xone support in rendering

--- a/.changeset/slimy-swans-move.md
+++ b/.changeset/slimy-swans-move.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-playground": patch
+---
+
+Added "labs" menu to toggle custom functionality

--- a/.changeset/tricky-snakes-peel.md
+++ b/.changeset/tricky-snakes-peel.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-core": patch
+---
+
+Adds links from property state to originting logical constraints

--- a/.changeset/tricky-snakes-peel.md
+++ b/.changeset/tricky-snakes-peel.md
@@ -2,4 +2,4 @@
 "@hydrofoil/shaperone-core": patch
 ---
 
-Adds links from property state to originting logical constraints
+Add logical constraints state to focus node state

--- a/demos/examples/ErrorSummary/index.ts
+++ b/demos/examples/ErrorSummary/index.ts
@@ -1,0 +1,28 @@
+import { decorate, FocusNodeTemplate } from '@hydrofoil/shaperone-wc/templates'
+import { html } from 'lit-html'
+import type { ValidationResult } from '@rdfine/shacl'
+import { shrink } from '@zazuko/rdf-vocabularies/shrink'
+
+function createMessage(result: ValidationResult) {
+  if (result.resultMessage) {
+    return result.resultMessage
+  }
+
+  if (result.sourceConstraintComponent) {
+    return `Violated ${shrink(result.sourceConstraintComponent.id.value)}`
+  }
+
+  return 'Form error'
+}
+
+export const errorSummary = decorate((focusNode: FocusNodeTemplate) => (context, args) => {
+  const summary = context.focusNode.validationResults
+    .filter(({ matchedTo }) => matchedTo !== 'object')
+    .map(({ result }) => html`<li>${createMessage(result)}</li>`)
+
+  if (summary.length) {
+    return html`<ul>${summary}</ul> ${focusNode(context, args)}`
+  }
+
+  return focusNode(context, args)
+})

--- a/demos/examples/NestedShapesIndividually/renderer.ts
+++ b/demos/examples/NestedShapesIndividually/renderer.ts
@@ -1,8 +1,8 @@
-import { FormTemplate } from '@hydrofoil/shaperone-wc/templates'
+import { decorate, FormTemplate } from '@hydrofoil/shaperone-wc/templates'
 import { html, css } from '@hydrofoil/shaperone-wc'
 
-export const topmostFocusNodeFormRenderer = (form: FormTemplate): FormTemplate => {
-  const formTemplate: FormTemplate = function (renderer) {
+export const topmostFocusNodeFormRenderer = decorate((form: FormTemplate): FormTemplate => {
+  const formTemplate: FormTemplate = (renderer) => {
     let backButton = html``
     if (renderer.context.state.focusStack.length > 1) {
       backButton = html`<a class="form-back-button" href="javascript:void(0)" @click="${renderer.actions.popFocusNode}">back</a>`
@@ -25,4 +25,4 @@ export const topmostFocusNodeFormRenderer = (form: FormTemplate): FormTemplate =
 }`
 
   return formTemplate
-}
+})

--- a/demos/examples/XoneRenderer/index.ts
+++ b/demos/examples/XoneRenderer/index.ts
@@ -2,34 +2,53 @@ import { FocusNodeTemplate } from '@hydrofoil/shaperone-wc/templates'
 import { html } from 'lit-html'
 import { LogicalConstraint } from '@hydrofoil/shaperone-core/models/forms'
 import type { Shape } from '@rdfine/shacl'
-import TermMap from '@rdf-esm/term-map'
 import { Term } from 'rdf-js'
 
-const selectedShapes = new TermMap<Term, Shape>()
+const selectedShapes = new WeakMap<Term, Shape>()
 
-function renderDropdown(onSelected: (xone: LogicalConstraint, shape: Shape) => void) {
-  return function (xone: LogicalConstraint) {
-    return html`<select @input="${(e: any) => onSelected(xone, xone.shapes[(e.target).selectedIndex])}">
+function renderDropdown(shapeSelected: (xone: LogicalConstraint, shape: Shape) => void) {
+  return (xone: LogicalConstraint) => {
+    function onInput(e: any) {
+      shapeSelected(xone, xone.shapes[(e.target).selectedIndex])
+    }
+
+    return html`<select @input="${onInput}">
       ${xone.shapes.map(shape => html`<option>${shape.label || shape.id.value}</option>`)}
     </select>`
   }
 }
 
+/**
+ * This function decorates a {@link FocusNodeTemplate} by rendering select menus for every `sh:xone` logical
+ * constraint found on the node shape. By switching the selected item in the dropdown, all properties within a
+ * `sh:xone` group will be hidden with the exception of the one selected.
+ *
+ * Hiding supports property shapes as well as node shapes which group multiple properties
+ *
+ * @param focusNodeTemplate
+ */
 export function focusNode(focusNodeTemplate: FocusNodeTemplate): FocusNodeTemplate {
-  const renderer: FocusNodeTemplate = function (context, args) {
+  const renderer: FocusNodeTemplate = (context, args) => {
     const { focusNode: { logicalConstraints: { xone } }, actions } = context
 
     for (const group of xone) {
+      // on initial render make sure that only the first shape from every
+      // sh:xone is shown and hide the rest
+      // using a WeakMap to prevent memory leaking when the form is removed from the page
       const selectedShape = selectedShapes.get(group.term.term)
       if (!selectedShape) {
-        group.shapes.forEach(shape => actions.hideProperty(shape))
-        actions.showProperty(group.shapes[0])
+        const [first, ...rest] = group.shapes
+        actions.showProperty(first)
+        rest.forEach(shape => actions.hideProperty(shape))
+
         selectedShapes.set(group.term.term, group.shapes[0])
       }
     }
 
     function select(xone: LogicalConstraint, shape: Shape) {
+      // when a shape is selected from, hide all properties
       xone.shapes.forEach(shape => actions.hideProperty(shape))
+      // and then show then show the selected
       actions.showProperty(shape)
     }
 

--- a/demos/examples/XoneRenderer/index.ts
+++ b/demos/examples/XoneRenderer/index.ts
@@ -1,0 +1,44 @@
+import { FocusNodeTemplate } from '@hydrofoil/shaperone-wc/templates'
+import { html } from 'lit-html'
+import { LogicalConstraint } from '@hydrofoil/shaperone-core/models/forms'
+import type { Shape } from '@rdfine/shacl'
+import TermMap from '@rdf-esm/term-map'
+import { Term } from 'rdf-js'
+
+const selectedShapes = new TermMap<Term, Shape>()
+
+function renderDropdown(onSelected: (xone: LogicalConstraint, shape: Shape) => void) {
+  return function (xone: LogicalConstraint) {
+    return html`<select @input="${(e: any) => onSelected(xone, xone.shapes[(e.target).selectedIndex])}">
+      ${xone.shapes.map(shape => html`<option>${shape.label || shape.id.value}</option>`)}
+    </select>`
+  }
+}
+
+export function focusNode(focusNodeTemplate: FocusNodeTemplate): FocusNodeTemplate {
+  const renderer: FocusNodeTemplate = function (context, args) {
+    const { focusNode: { logicalConstraints: { xone } }, actions } = context
+
+    for (const group of xone) {
+      const selectedShape = selectedShapes.get(group.term.term)
+      if (!selectedShape) {
+        group.shapes.forEach(shape => actions.hideProperty(shape))
+        actions.showProperty(group.shapes[0])
+        selectedShapes.set(group.term.term, group.shapes[0])
+      }
+    }
+
+    function select(xone: LogicalConstraint, shape: Shape) {
+      xone.shapes.forEach(shape => actions.hideProperty(shape))
+      actions.showProperty(shape)
+    }
+
+    return html`
+      ${xone.map(renderDropdown(select))}
+      ${focusNodeTemplate(context, args)}`
+  }
+
+  renderer.loadDependencies = focusNodeTemplate.loadDependencies
+
+  return renderer
+}

--- a/demos/examples/XoneRenderer/index.ts
+++ b/demos/examples/XoneRenderer/index.ts
@@ -1,4 +1,4 @@
-import { FocusNodeTemplate } from '@hydrofoil/shaperone-wc/templates'
+import { decorate, FocusNodeTemplate } from '@hydrofoil/shaperone-wc/templates'
 import { html } from 'lit-html'
 import { LogicalConstraint } from '@hydrofoil/shaperone-core/models/forms'
 import type { Shape } from '@rdfine/shacl'
@@ -27,37 +27,31 @@ function renderDropdown(shapeSelected: (xone: LogicalConstraint, shape: Shape) =
  *
  * @param focusNodeTemplate
  */
-export function focusNode(focusNodeTemplate: FocusNodeTemplate): FocusNodeTemplate {
-  const renderer: FocusNodeTemplate = (context, args) => {
-    const { focusNode: { logicalConstraints: { xone } }, actions } = context
+export const focusNode = decorate((focusNodeTemplate: FocusNodeTemplate) => (context, args) => {
+  const { focusNode: { logicalConstraints: { xone } }, actions } = context
 
-    for (const group of xone) {
-      // on initial render make sure that only the first shape from every
-      // sh:xone is shown and hide the rest
-      // using a WeakMap to prevent memory leaking when the form is removed from the page
-      const selectedShape = selectedShapes.get(group.term.term)
-      if (!selectedShape) {
-        const [first, ...rest] = group.shapes
-        actions.showProperty(first)
-        rest.forEach(shape => actions.hideProperty(shape))
+  for (const group of xone) {
+    // on initial render make sure that only the first shape from every
+    // sh:xone is shown and hide the rest
+    // using a WeakMap to prevent memory leaking when the form is removed from the page
+    const selectedShape = selectedShapes.get(group.term.term)
+    if (!selectedShape) {
+      const [first, ...rest] = group.shapes
+      actions.showProperty(first)
+      rest.forEach(shape => actions.hideProperty(shape))
 
-        selectedShapes.set(group.term.term, group.shapes[0])
-      }
+      selectedShapes.set(group.term.term, group.shapes[0])
     }
-
-    function select(xone: LogicalConstraint, shape: Shape) {
-      // when a shape is selected from, hide all properties
-      xone.shapes.forEach(shape => actions.hideProperty(shape))
-      // and then show then show the selected
-      actions.showProperty(shape)
-    }
-
-    return html`
-      ${xone.map(renderDropdown(select))}
-      ${focusNodeTemplate(context, args)}`
   }
 
-  renderer.loadDependencies = focusNodeTemplate.loadDependencies
+  function select(xone: LogicalConstraint, shape: Shape) {
+    // when a shape is selected from, hide all properties
+    xone.shapes.forEach(shape => actions.hideProperty(shape))
+    // and then show then show the selected
+    actions.showProperty(shape)
+  }
 
-  return renderer
-}
+  return html`
+      ${xone.map(renderDropdown(select))}
+      ${focusNodeTemplate(context, args)}`
+})

--- a/demos/examples/package.json
+++ b/demos/examples/package.json
@@ -13,6 +13,7 @@
     "@hydrofoil/shaperone-core": "0.6.9",
     "@hydrofoil/shaperone-wc": "0.4.6",
     "@rdf-esm/data-model": "^0.5.3",
+    "@zazuko/rdf-vocabularies": "*",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "multiselect-combo-box": "^2.4.2"

--- a/demos/examples/package.json
+++ b/demos/examples/package.json
@@ -13,7 +13,6 @@
     "@hydrofoil/shaperone-core": "0.6.9",
     "@hydrofoil/shaperone-wc": "0.4.6",
     "@rdf-esm/data-model": "^0.5.3",
-    "@rdf-esm/term-map": "^0.5.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "multiselect-combo-box": "^2.4.2"

--- a/demos/examples/package.json
+++ b/demos/examples/package.json
@@ -13,6 +13,7 @@
     "@hydrofoil/shaperone-core": "0.6.9",
     "@hydrofoil/shaperone-wc": "0.4.6",
     "@rdf-esm/data-model": "^0.5.3",
+    "@rdf-esm/term-map": "^0.5.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "multiselect-combo-box": "^2.4.2"

--- a/demos/lit-html/src/configure.ts
+++ b/demos/lit-html/src/configure.ts
@@ -8,7 +8,7 @@ import { DescriptionTooltip } from '@hydrofoil/shaperone-playground-examples/Des
 import * as vaadinComponents from '@hydrofoil/shaperone-wc-vaadin/components'
 import { components, editors, renderer, validation } from '@hydrofoil/shaperone-wc/configure'
 import { dash } from '@tpluscode/rdf-ns-builders'
-import { templates } from '@hydrofoil/shaperone-wc/templates'
+import { Decorate, RenderTemplate, templates } from '@hydrofoil/shaperone-wc/templates'
 import * as MaterialRenderStrategy from '@hydrofoil/shaperone-wc-material/renderer'
 import { instancesSelector } from '@hydrofoil/shaperone-hydra/components'
 import { validate } from '@hydrofoil/shaperone-rdf-validate-shacl'
@@ -16,6 +16,7 @@ import $rdf from 'rdf-ext'
 import * as xone from '@hydrofoil/shaperone-playground-examples/XoneRenderer'
 import { ComponentsState } from './state/models/components'
 import { RendererState } from './state/models/renderer'
+import { errorSummary } from '../../examples/ErrorSummary'
 
 export const componentSets: Record<ComponentsState['components'], Record<string, Component>> = {
   native: { ...nativeComponents, starRating },
@@ -49,11 +50,27 @@ export const selectComponents = (() => {
   }
 })()
 
+function combineDecorators<Template extends RenderTemplate>(combined: Template, next: Decorate<Template>) {
+  return next(combined)
+}
+
 export const configureRenderer = (() => {
+  function * focusNodeDecorators(labs: RendererState['labs']) {
+    if (labs?.xone) {
+      yield xone.focusNode
+    }
+    if (labs?.errorSummary) {
+      yield errorSummary
+    }
+    yield MaterialRenderStrategy.focusNode
+  }
+
+  let focusNodeTemplate = templates.focusNode
+
   const initialStrategy = {
     ...templates,
     ...MaterialRenderStrategy,
-    focusNode: MaterialRenderStrategy.focusNode(xone.focusNode(templates.focusNode)),
+    focusNode: [...focusNodeDecorators({})].reduce(combineDecorators, focusNodeTemplate),
   }
 
   renderer.setTemplates(initialStrategy)
@@ -83,7 +100,7 @@ export const configureRenderer = (() => {
       }
     },
 
-    async switchLayout({ grouping }: RendererState) {
+    async switchLayout({ grouping, labs }: RendererState) {
       if (previousGrouping === grouping) return
       previousGrouping = grouping
 
@@ -99,7 +116,7 @@ export const configureRenderer = (() => {
         } = await import('@hydrofoil/shaperone-wc-vaadin/renderer/accordion')
 
         strategy.group = AccordionGroupingRenderer
-        strategy.focusNode = MaterialRenderStrategy.focusNode(xone.focusNode(AccordionFocusNodeRenderer))
+        focusNodeTemplate = AccordionFocusNodeRenderer
       } else if (grouping === 'material tabs') {
         const {
           TabsGroupRenderer,
@@ -107,10 +124,17 @@ export const configureRenderer = (() => {
         } = await import('@hydrofoil/shaperone-wc-material/renderer/tabs')
 
         strategy.group = TabsGroupRenderer
-        strategy.focusNode = MaterialRenderStrategy.focusNode(xone.focusNode(TabsFocusNodeRenderer))
+        focusNodeTemplate = TabsFocusNodeRenderer
       }
 
+      strategy.focusNode = [...focusNodeDecorators(labs)].reduce(combineDecorators, focusNodeTemplate)
       renderer.setTemplates(strategy)
+    },
+
+    async setLabs({ labs }: RendererState) {
+      renderer.setTemplates({
+        focusNode: [...focusNodeDecorators(labs)].reduce(combineDecorators, focusNodeTemplate),
+      })
     },
   }
 })()

--- a/demos/lit-html/src/configure.ts
+++ b/demos/lit-html/src/configure.ts
@@ -13,6 +13,7 @@ import * as MaterialRenderStrategy from '@hydrofoil/shaperone-wc-material/render
 import { instancesSelector } from '@hydrofoil/shaperone-hydra/components'
 import { validate } from '@hydrofoil/shaperone-rdf-validate-shacl'
 import $rdf from 'rdf-ext'
+import * as xone from '@hydrofoil/shaperone-playground-examples/XoneRenderer'
 import { ComponentsState } from './state/models/components'
 import { RendererState } from './state/models/renderer'
 
@@ -52,7 +53,7 @@ export const configureRenderer = (() => {
   const initialStrategy = {
     ...templates,
     ...MaterialRenderStrategy,
-    focusNode: MaterialRenderStrategy.focusNode(templates.focusNode),
+    focusNode: MaterialRenderStrategy.focusNode(xone.focusNode(templates.focusNode)),
   }
 
   renderer.setTemplates(initialStrategy)
@@ -98,7 +99,7 @@ export const configureRenderer = (() => {
         } = await import('@hydrofoil/shaperone-wc-vaadin/renderer/accordion')
 
         strategy.group = AccordionGroupingRenderer
-        strategy.focusNode = MaterialRenderStrategy.focusNode(AccordionFocusNodeRenderer)
+        strategy.focusNode = MaterialRenderStrategy.focusNode(xone.focusNode(AccordionFocusNodeRenderer))
       } else if (grouping === 'material tabs') {
         const {
           TabsGroupRenderer,
@@ -106,7 +107,7 @@ export const configureRenderer = (() => {
         } = await import('@hydrofoil/shaperone-wc-material/renderer/tabs')
 
         strategy.group = TabsGroupRenderer
-        strategy.focusNode = MaterialRenderStrategy.focusNode(TabsFocusNodeRenderer)
+        strategy.focusNode = MaterialRenderStrategy.focusNode(xone.focusNode(TabsFocusNodeRenderer))
       }
 
       renderer.setTemplates(strategy)

--- a/demos/lit-html/src/menu.ts
+++ b/demos/lit-html/src/menu.ts
@@ -1,6 +1,6 @@
 export interface Menu {
   id?: string
-  type?: 'layout' | 'renderer' | 'format' | 'components' | 'editorChoice'
+  type?: 'layout' | 'renderer' | 'format' | 'components' | 'editorChoice' | 'labs'
   text?: string
   checked?: boolean
   children?: Menu[]

--- a/demos/lit-html/src/menu/formMenu.ts
+++ b/demos/lit-html/src/menu/formMenu.ts
@@ -1,3 +1,5 @@
+import { html } from 'lit-element'
+import { render } from 'lit-html'
 import { ComponentsState } from '../state/models/components'
 import { RendererState } from '../state/models/renderer'
 import { componentSets } from '../configure'
@@ -20,7 +22,32 @@ function componentsMenu(components: ComponentsState): Menu {
   }
 }
 
+const menuItem = (() => {
+  const items = new Map<string, HTMLElement>()
+
+  return function menuItem(title: string, subtext: string, checked: boolean) {
+    let item = items.get(title)
+    if (!item) {
+      item = document.createElement('vaadin-context-menu-item')
+      items.set(title, item)
+    }
+
+    if (checked) {
+      item.setAttribute('menu-item-checked', '')
+    } else {
+      item.removeAttribute('menu-item-checked')
+    }
+
+    render(html`<div>${title}</div><div><small>${subtext}</small></div>`, item)
+
+    return item
+  }
+})()
+
 function rendererMenu(renderer: RendererState): Menu[] {
+  const labCount = Object.values(renderer.labs || {}).filter(lab => lab).length
+  const labBadgeCode = labCount === 0 ? 0x24ff : 0x2775 + labCount
+
   return [
     {
       text: 'Layout',
@@ -28,17 +55,17 @@ function rendererMenu(renderer: RendererState): Menu[] {
         text: 'No grouping',
         checked: renderer.grouping === 'none',
         type: 'layout',
-        id: 'none' as RendererState['grouping'],
+        id: 'none',
       }, {
         text: 'Material tabs',
         checked: renderer.grouping === 'material tabs',
         type: 'layout',
-        id: 'material tabs' as RendererState['grouping'],
+        id: 'material tabs',
       }, {
         text: 'Vaadin accordion',
         checked: renderer.grouping === 'vaadin accordion',
         type: 'layout',
-        id: 'vaadin accordion' as RendererState['grouping'],
+        id: 'vaadin accordion',
       }],
     }, {
       text: 'Nested shapes',
@@ -57,6 +84,25 @@ function rendererMenu(renderer: RendererState): Menu[] {
         checked: renderer.nesting === 'inline',
         id: 'inline',
         type: 'renderer',
+      }],
+    }, {
+      text: `Labs (${String.fromCharCode(labBadgeCode)})`,
+      children: [{
+        component: menuItem(
+          'Error summary',
+          'Display additional errors on top',
+          renderer.labs?.errorSummary === true,
+        ),
+        id: 'errorSummary',
+        type: 'labs',
+      }, {
+        component: menuItem(
+          'sh:xone selector menus',
+          'May require reload when disabled',
+          renderer.labs?.xone === true,
+        ),
+        id: 'xone',
+        type: 'labs',
       }],
     }]
 }

--- a/demos/lit-html/src/shaperone-playground-lit.ts
+++ b/demos/lit-html/src/shaperone-playground-lit.ts
@@ -226,6 +226,9 @@ export class ShaperonePlayground extends connect(store(), LitElement) {
       case 'renderer':
         store().dispatch.rendererSettings.switchNesting(e.detail.value.id)
         break
+      case 'labs':
+        store().dispatch.rendererSettings.toggleLab({ lab: e.detail.value.id })
+        break
       default:
         break
     }
@@ -294,6 +297,7 @@ export class ShaperonePlayground extends connect(store(), LitElement) {
     selectComponents(state.componentsSettings.components)
     configureRenderer.switchLayout(state.rendererSettings)
     configureRenderer.switchNesting(state.rendererSettings)
+    configureRenderer.setLabs(state.rendererSettings)
 
     return {
       components: state.componentsSettings,

--- a/demos/lit-html/src/state/models/playground.ts
+++ b/demos/lit-html/src/state/models/playground.ts
@@ -109,6 +109,10 @@ export const playground = createModel({
       'rendererSettings/switchLayout': function (value: string) {
         dispatch.playground.updateSharingParams({ key: 'grouping', value })
       },
+      'rendererSettings/toggleLab': function () {
+        const { labs } = store.getState().rendererSettings
+        dispatch.playground.updateSharingParams({ key: 'labs', value: JSON.stringify(labs) })
+      },
       'shape/error': function (error: Error | undefined) {
         dispatch.playground.error(typeof error !== 'undefined')
       },
@@ -128,6 +132,7 @@ export const playground = createModel({
         const disableEditorChoice = sharedState.get('disableEditorChoice')
         const components = sharedState.get('components')
         const selectedResource = sharedState.get('selectedResource')
+        const labs = sharedState.get('labs')
 
         if (shapesFormat) {
           dispatch.shape.format(shapesFormat)
@@ -158,6 +163,11 @@ export const playground = createModel({
         }
         if (components) {
           dispatch.componentsSettings.switchComponents(components as any)
+        }
+        if (labs) {
+          for (const [lab, value] of Object.entries(JSON.parse(labs)) as any) {
+            dispatch.rendererSettings.toggleLab({ lab, value })
+          }
         }
 
         [...url.searchParams.keys()].forEach(key => url.searchParams.delete(key))

--- a/demos/lit-html/src/state/models/renderer.ts
+++ b/demos/lit-html/src/state/models/renderer.ts
@@ -3,6 +3,10 @@ import { createModel } from '@captaincodeman/rdx'
 export interface RendererState {
   grouping: 'none' | 'material tabs' | 'vaadin accordion'
   nesting: 'none' | 'always one' | 'inline'
+  labs?: {
+    xone?: boolean
+    errorSummary?: boolean
+  }
 }
 
 export const rendererSettings = createModel({
@@ -21,6 +25,15 @@ export const rendererSettings = createModel({
       return {
         ...state,
         grouping,
+      }
+    },
+    toggleLab({ labs = {}, ...state }, { lab, value } : {lab: keyof Required<RendererState>['labs']; value?: boolean}) {
+      return {
+        ...state,
+        labs: {
+          ...labs,
+          [lab]: typeof value !== 'undefined' ? value : !labs[lab],
+        },
       }
     },
   },

--- a/packages/core/models/forms/index.ts
+++ b/packages/core/models/forms/index.ts
@@ -5,8 +5,9 @@
 
 import { createModel } from '@captaincodeman/rdx'
 import { NamedNode } from 'rdf-js'
-import type { NodeShape, PropertyGroup, PropertyShape, ValidationResult } from '@rdfine/shacl'
+import type { NodeShape, PropertyGroup, PropertyShape, Shape, ValidationResult } from '@rdfine/shacl'
 import { GraphPointer } from 'clownface'
+import type { sh } from '@tpluscode/rdf-ns-builders'
 import effects from './effects'
 import { addFormField } from './reducers/addFormField'
 import { popFocusNode } from './reducers/popFocusNode'
@@ -20,6 +21,7 @@ import * as connection from './reducers/connection'
 import * as editors from './reducers/editors'
 import * as multiEditors from './reducers/multiEditors'
 import * as validation from './reducers/validation'
+import * as properties from './reducers/properties'
 import { FocusNode } from '../../index'
 import type { MultiEditor, SingleEditorMatch } from '../editors'
 import { createFocusNodeState } from './reducers/replaceFocusNodes'
@@ -75,6 +77,18 @@ export interface ShouldEnableEditorChoice {
   (params?: { object?: GraphPointer }): boolean
 }
 
+export interface LogicalConstraint<Type extends NamedNode = typeof sh.AndConstraintComponent | typeof sh.OrConstraintComponent | typeof sh.XoneConstraintComponent> {
+  term: GraphPointer
+  shapes: Shape[]
+  component: Type
+}
+
+export interface LogicalConstraints {
+  and: LogicalConstraint<typeof sh.AndConstraintComponent>[]
+  or: LogicalConstraint<typeof sh.OrConstraintComponent>[]
+  xone: LogicalConstraint<typeof sh.XoneConstraintComponent>[]
+}
+
 export interface PropertyState extends ValidationState {
   shape: PropertyShape
   name: string
@@ -100,6 +114,7 @@ export interface FocusNodeState extends ValidationState {
   shapes: NodeShape[]
   properties: PropertyState[]
   groups: PropertyGroupState[]
+  logicalConstraints: LogicalConstraints
 }
 
 export interface FormSettings {
@@ -132,6 +147,7 @@ const reducers = {
   ...editors,
   ...multiEditors,
   createFocusNodeState,
+  ...properties,
   ...validation,
 }
 

--- a/packages/core/models/forms/lib/property.ts
+++ b/packages/core/models/forms/lib/property.ts
@@ -1,6 +1,10 @@
 import type { PropertyShape, Shape } from '@rdfine/shacl'
 import { sh } from '@tpluscode/rdf-ns-builders'
 import { fromPointer } from '@rdfine/shacl/lib/PropertyShape'
+import { fromPointer as createShape } from '@rdfine/shacl/lib/Shape'
+import { BlankNode, NamedNode } from 'rdf-js'
+import type { GraphPointer } from 'clownface'
+import type { LogicalConstraints } from '../index'
 
 export function canAddObject(property: PropertyShape, length: number): boolean {
   return length < (property.maxCount || Number.POSITIVE_INFINITY)
@@ -10,23 +14,72 @@ export function canRemoveObject(property: PropertyShape, length: number): boolea
   return length > (property.minCount || 0)
 }
 
-function isPropertyShape(shape: Shape): shape is PropertyShape {
-  return shape.pointer.out(sh.path).terms.length > 0
+function isPropertyShape(shape: GraphPointer): boolean {
+  return shape.out(sh.path).terms.length > 0
 }
 
-function getProperties(shape: Shape): PropertyShape[] {
-  if (isPropertyShape(shape)) {
-    return [fromPointer(shape.pointer)]
+function isResourceNode(ptr: GraphPointer): ptr is GraphPointer<BlankNode> | GraphPointer<NamedNode> {
+  return ptr.term.termType === 'BlankNode' || ptr.term.termType === 'NamedNode'
+}
+
+function getProperties(constraint: GraphPointer): PropertyShape[] {
+  const list = constraint.list()
+  if (!list) {
+    return []
   }
 
-  return shape.property
+  return [...list].reduce<PropertyShape[]>((shapes, shape) => {
+    if (!isResourceNode(shape)) {
+      return shapes
+    }
+
+    if (isPropertyShape(shape)) {
+      return [...shapes, fromPointer(shape)]
+    }
+
+    return [...shapes, ...shape.out(sh.property).filter(isResourceNode).map((ptr: any) => fromPointer(ptr))]
+  }, [])
 }
 
-export function combineProperties(shape: Shape): PropertyShape[] {
-  return [
-    shape,
-    ...shape.and,
-    ...shape.or,
-    ...shape.xone,
-  ].flatMap(getProperties)
+export function combineProperties(shape: Shape): { properties: PropertyShape[]; logicalConstraints: LogicalConstraints } {
+  let properties: PropertyShape[] = shape.property
+  const logicalConstraints: LogicalConstraints = { xone: [], and: [], or: [] }
+
+  for (const constraint of shape.pointer.out(sh.and).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.and.push({
+        term: constraint,
+        component: sh.AndConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  for (const constraint of shape.pointer.out(sh.or).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.or.push({
+        term: constraint,
+        component: sh.OrConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  for (const constraint of shape.pointer.out(sh.xone).toArray()) {
+    const list = constraint.list()
+    if (list) {
+      properties = [...properties, ...getProperties(constraint)]
+      logicalConstraints.xone.push({
+        term: constraint,
+        component: sh.XoneConstraintComponent,
+        shapes: [...list].filter(isResourceNode).map((ptr: any) => createShape(ptr)),
+      })
+    }
+  }
+
+  return { properties, logicalConstraints }
 }

--- a/packages/core/models/forms/reducers/properties.ts
+++ b/packages/core/models/forms/reducers/properties.ts
@@ -9,20 +9,17 @@ export interface ToggleParams extends BaseParams {
   shape: Shape
 }
 
-export const showProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
-  const focusNodeState = state.focusNodes[focusNode.value]
-  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+function setHidden(hidden: boolean) {
+  return (state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
+    const focusNodeState = state.focusNodes[focusNode.value]
+    const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
 
-  for (const propertyState of propertyStates) {
-    propertyState.hidden = false
-  }
-}))
+    for (const propertyState of propertyStates) {
+      propertyState.hidden = hidden
+    }
+  })
+}
 
-export const hideProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
-  const focusNodeState = state.focusNodes[focusNode.value]
-  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+export const showProperty = formStateReducer(setHidden(false))
 
-  for (const propertyState of propertyStates) {
-    propertyState.hidden = true
-  }
-}))
+export const hideProperty = formStateReducer(setHidden(true))

--- a/packages/core/models/forms/reducers/properties.ts
+++ b/packages/core/models/forms/reducers/properties.ts
@@ -1,0 +1,28 @@
+import produce from 'immer'
+import type { Shape } from '@rdfine/shacl'
+import { BaseParams, formStateReducer } from '../../index'
+import type { FormState } from '../index'
+import { FocusNode } from '../../../index'
+
+export interface ToggleParams extends BaseParams {
+  focusNode: FocusNode
+  shape: Shape
+}
+
+export const showProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
+  const focusNodeState = state.focusNodes[focusNode.value]
+  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+
+  for (const propertyState of propertyStates) {
+    propertyState.hidden = false
+  }
+}))
+
+export const hideProperty = formStateReducer((state: FormState, { focusNode, shape }: ToggleParams) => produce(state, (state) => {
+  const focusNodeState = state.focusNodes[focusNode.value]
+  const propertyStates = focusNodeState.properties.filter(p => p.shape.equals(shape) || shape.property.some(property => p.shape.equals(property)))
+
+  for (const propertyState of propertyStates) {
+    propertyState.hidden = true
+  }
+}))

--- a/packages/core/renderer.ts
+++ b/packages/core/renderer.ts
@@ -3,7 +3,7 @@
  * @module @hydrofoil/shaperone-core/renderer
  */
 
-import type { NodeShape } from '@rdfine/shacl'
+import type { NodeShape, Shape } from '@rdfine/shacl'
 import { PropertyGroup } from '@rdfine/shacl'
 import { NamedNode, Term } from 'rdf-js'
 import type { GraphPointer } from 'clownface'
@@ -84,6 +84,9 @@ export interface FocusNodeActions {
    * @param shape
    */
   selectShape (shape: NodeShape): void
+
+  hideProperty (shape: Shape): void
+  showProperty (shape: Shape): void
 }
 
 /**

--- a/packages/core/test/models/forms/lib/stateBuilder.test.ts
+++ b/packages/core/test/models/forms/lib/stateBuilder.test.ts
@@ -375,6 +375,78 @@ describe('core/models/forms/lib/stateBuilder', () => {
       expect(state.properties).to.have.length(6)
     })
 
+    it('adds logical constraint groups to focus node state', () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const focusNode = graph.node(ex.Person)
+      const shape = fromPointer(graph.blankNode(), {
+        or: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+        and: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+        xone: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+      })
+
+      // when
+      const state = initialiseFocusNode({
+        focusNode,
+        editors: store.getState().editors,
+        shape,
+        shapes: [],
+        shouldEnableEditorChoice: () => true,
+      }, undefined)
+
+      // then
+      expect(state.logicalConstraints.or).to.have.length(1)
+      expect(state.logicalConstraints.and).to.have.length(1)
+      expect(state.logicalConstraints.xone).to.have.length(1)
+    })
+
+    it('provides pointers to logical constraints a property may be part of', () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const focusNode = graph.node(ex.Person)
+      const shape = fromPointer(graph.blankNode(), {
+        or: [{
+          types: [sh.NodeShape],
+          property: {
+            path: ex.firstName,
+            types: [sh.PropertyShape],
+          },
+        }],
+      })
+
+      // when
+      const state = initialiseFocusNode({
+        focusNode,
+        editors: store.getState().editors,
+        shape,
+        shapes: [],
+        shouldEnableEditorChoice: () => true,
+      }, undefined)
+
+      // then
+      const logicalConstraint = state.logicalConstraints.or[0]
+      expect(logicalConstraint.term.term).to.deep.equal(shape.pointer.out(sh.or).term)
+      expect(logicalConstraint.component).to.deep.equal(sh.OrConstraintComponent)
+    })
+
     it('combines all property shapes from logical constraints, defined without wrapping node shape', () => {
       // given
       const graph = cf({ dataset: $rdf.dataset() })

--- a/packages/core/test/models/forms/reducers/properties.test.ts
+++ b/packages/core/test/models/forms/reducers/properties.test.ts
@@ -1,0 +1,90 @@
+import { testFocusNodeState, testPropertyState, testStore } from '@shaperone/testing/models/form'
+import clownface from 'clownface'
+import $rdf from 'rdf-ext'
+import { expect } from 'chai'
+import { blankNode } from '@shaperone/testing/nodeFactory'
+import { fromPointer } from '@rdfine/shacl/lib/NodeShape'
+import { sh } from '@tpluscode/rdf-ns-builders'
+import { hideProperty, showProperty } from '../../../../models/forms/reducers/properties'
+import { Store } from '../../../../state'
+import { FocusNode } from '../../../../index'
+import { PropertyState } from '../../../../models/forms'
+
+describe('@hydrofoil/shaperone-core/models/forms/reducers/properties', () => {
+  let store: Store
+  let form: symbol
+  let focusNode: FocusNode
+
+  beforeEach(() => {
+    ({ form, store } = testStore())
+    focusNode = clownface({ dataset: $rdf.dataset() }).blankNode()
+  })
+
+  describe('hideProperty', () => {
+    it('hides property shape itself', () => {
+      // given
+      const property = testPropertyState()
+      store.getState().forms.get(form)!.focusNodes = testFocusNodeState(focusNode, {
+        properties: [property],
+      })
+
+      // when
+      const after = hideProperty(store.getState().forms, { form, focusNode, shape: property.shape })
+
+      // then
+      expect(after.get(form)?.focusNodes[focusNode.value].properties[0].hidden).to.be.true
+    })
+
+    it('hides property shapes of given node shape', () => {
+      // given
+      const shape = blankNode()
+        .addOut(sh.property)
+        .addOut(sh.property)
+        .addOut(sh.property)
+      store.getState().forms.get(form)!.focusNodes = testFocusNodeState(focusNode, {
+        properties: shape.out(sh.property).map((node: any) => testPropertyState(node)),
+      })
+
+      // when
+      const after = hideProperty(store.getState().forms, { form, focusNode, shape: fromPointer(shape) })
+
+      // then
+      expect(after.get(form)?.focusNodes[focusNode.value].properties).to.containAll<PropertyState>(shape => shape.hidden)
+    })
+  })
+
+  describe('showProperty', () => {
+    it('show property shape itself', () => {
+      // given
+      const property = testPropertyState(blankNode(), {
+        hidden: true,
+      })
+      store.getState().forms.get(form)!.focusNodes = testFocusNodeState(focusNode, {
+        properties: [property],
+      })
+
+      // when
+      const after = showProperty(store.getState().forms, { form, focusNode, shape: property.shape })
+
+      // then
+      expect(after.get(form)?.focusNodes[focusNode.value].properties[0].hidden).to.be.false
+    })
+
+    it('show property shapes of given node shape', () => {
+      // given
+      const shape = blankNode()
+        .addOut(sh.property)
+        .addOut(sh.property)
+        .addOut(sh.property)
+      store.getState().forms.get(form)!.focusNodes = testFocusNodeState(focusNode, {
+        properties: shape.out(sh.property).map((node: any) => testPropertyState(node, { hidden: true })),
+      })
+
+      // when
+      const after = showProperty(store.getState().forms, { form, focusNode, shape: fromPointer(shape) })
+
+      // then
+      expect(after.get(form)?.focusNodes[focusNode.value].properties).to.containAll<PropertyState>(shape => !shape.hidden)
+    })
+  })
+})

--- a/packages/testing/renderer.ts
+++ b/packages/testing/renderer.ts
@@ -57,6 +57,8 @@ export const focusNodeRenderer = (arg: TestFocusNode): sinon.SinonStubbedInstanc
       ...form.actions,
       selectGroup: sinon.spy(),
       selectShape: sinon.spy(),
+      hideProperty: sinon.spy(),
+      showProperty: sinon.spy(),
     },
   })
 }

--- a/packages/wc-material/renderer/index.ts
+++ b/packages/wc-material/renderer/index.ts
@@ -1,10 +1,10 @@
 import { css, html } from 'lit-element'
 import { repeat } from 'lit-html/directives/repeat'
-import { FocusNodeTemplate, ObjectTemplate, PropertyTemplate } from '@hydrofoil/shaperone-wc/templates'
+import { FocusNodeTemplate, ObjectTemplate, PropertyTemplate, decorate } from '@hydrofoil/shaperone-wc/templates'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
 
-export const focusNode = (currentStrategy: FocusNodeTemplate): FocusNodeTemplate => {
-  const renderer: FocusNodeTemplate = function (renderer, params) {
+export const focusNode = decorate((currentStrategy: FocusNodeTemplate): FocusNodeTemplate => {
+  const renderer: FocusNodeTemplate = (renderer, params) => {
     const { actions } = renderer
     const { focusNode } = params
 
@@ -23,17 +23,12 @@ export const focusNode = (currentStrategy: FocusNodeTemplate): FocusNodeTemplate
   ${currentStrategy(renderer, params)}`
   }
 
-  renderer.loadDependencies = () => {
-    const inheritedDependencies = currentStrategy.loadDependencies?.() || []
-
-    return [
-      import('../elements/mwc-shape-selector'),
-      ...inheritedDependencies,
-    ]
-  }
+  renderer.loadDependencies = () => [
+    import('../elements/mwc-shape-selector'),
+  ]
 
   return renderer
-}
+})
 
 export const property: PropertyTemplate = function (renderer, param) {
   const { actions } = renderer

--- a/packages/wc/renderer/decorator.ts
+++ b/packages/wc/renderer/decorator.ts
@@ -1,0 +1,58 @@
+/**
+ * Decorator module simplifies extending render templates
+ *
+ * @packageDocumentation
+ * @module @hydrofoil/shaperone-wc/components/decorator
+ */
+
+import { css } from 'lit-element'
+import type { RenderTemplate } from '../templates'
+
+export interface Decorate<Template extends RenderTemplate> {
+  (template: Template): Template
+}
+
+function combineInit(base: RenderTemplate, decorated: RenderTemplate) {
+  const { loadDependencies } = decorated
+
+  if (!loadDependencies) {
+    decorated.loadDependencies = base.loadDependencies
+    return
+  }
+
+  const baseDependencies = base.loadDependencies
+  if (baseDependencies) {
+    decorated.loadDependencies = () => [
+      ...baseDependencies(),
+      ...loadDependencies(),
+    ]
+  }
+}
+
+function combineStyles(base: RenderTemplate, decorated: RenderTemplate) {
+  if (!decorated.styles) {
+    decorated.styles = base.styles
+    return
+  }
+
+  if (base.styles) {
+    decorated.styles = css`${base.styles as any}\n${decorated.styles as any}`
+  }
+}
+
+/**
+ * Wraps the rendering function of a {@see RenderTemplate}, allowing extending existing templates.
+ *
+ * @param decorate function to wrap another template
+ * @return wrapped template function
+ */
+export function decorate<Template extends RenderTemplate>(decorate: Decorate<Template>): Decorate<Template> {
+  return (baseTemplate: Template) => {
+    const decorated = decorate(baseTemplate)
+
+    combineInit(baseTemplate, decorated)
+    combineStyles(baseTemplate, decorated)
+
+    return decorated
+  }
+}

--- a/packages/wc/renderer/focusNode.ts
+++ b/packages/wc/renderer/focusNode.ts
@@ -1,6 +1,6 @@
 import { FormRenderer, FocusNodeRenderer } from '@hydrofoil/shaperone-core/renderer'
 import { TemplateResult } from 'lit-element'
-import { NodeShape, PropertyGroup } from '@rdfine/shacl'
+import { NodeShape, PropertyGroup, Shape } from '@rdfine/shacl'
 import { renderGroup } from './group'
 
 export const renderFocusNode: FormRenderer['renderFocusNode'] = function ({ focusNode, shape }): TemplateResult {
@@ -21,6 +21,8 @@ export const renderFocusNode: FormRenderer['renderFocusNode'] = function ({ focu
     ...this.actions,
     selectGroup: (group: PropertyGroup | undefined) => dispatch.forms.selectGroup({ form, focusNode, group }),
     selectShape: (shape: NodeShape) => dispatch.forms.selectShape({ form, focusNode, shape }),
+    hideProperty: (shape: Shape) => dispatch.forms.hideProperty({ form, focusNode, shape }),
+    showProperty: (shape: Shape) => dispatch.forms.showProperty({ form, focusNode, shape }),
   }
 
   const context: FocusNodeRenderer = {

--- a/packages/wc/templates.ts
+++ b/packages/wc/templates.ts
@@ -9,6 +9,8 @@ import { repeat } from 'lit-html/directives/repeat'
 import type { FocusNodeRenderer, FormRenderer, GroupRenderer, ObjectRenderer, PropertyRenderer } from '@hydrofoil/shaperone-core/renderer'
 import { NamedNode } from 'rdf-js'
 
+export * from './renderer/decorator'
+
 /**
  * Base template. Extend to create templates which can dynamically load dependencies or inject CSS styles
  */

--- a/packages/wc/test/renderer/decorator.test.ts
+++ b/packages/wc/test/renderer/decorator.test.ts
@@ -1,0 +1,87 @@
+import { html } from 'lit-html'
+import { expect } from '@open-wc/testing'
+import { sinon } from '@shaperone/testing'
+import { css } from 'lit-element'
+import { decorate } from '../../renderer/decorator'
+import { FocusNodeTemplate } from '../../templates'
+
+describe('@hydrofoil/shaperone-wc/components/decorator', () => {
+  describe('.loadDependencies', () => {
+    it('gets combined from base and extension', async () => {
+      // given
+      const base: FocusNodeTemplate = function () {
+        return html``
+      }
+      base.loadDependencies = sinon.stub().returns([])
+      const decoratedDeps = sinon.stub().returns([])
+
+      // when
+      const decorated = decorate((template: FocusNodeTemplate) => {
+        const decorated: FocusNodeTemplate = (c, a) => template(c, a)
+
+        decorated.loadDependencies = decoratedDeps
+
+        return decorated
+      })(base)
+      await Promise.all(decorated.loadDependencies!())
+
+      // then
+      expect(base.loadDependencies).to.have.been.called
+      expect(decoratedDeps).to.have.been.called
+    })
+
+    it('resues base dependencies', async () => {
+      // given
+      const base: FocusNodeTemplate = function () {
+        return html``
+      }
+      base.loadDependencies = sinon.stub().returns([])
+
+      // when
+      const decorated = decorate((template: FocusNodeTemplate) => (c, a) => template(c, a))(base)
+      await Promise.all(decorated.loadDependencies!())
+
+      // then
+      expect(base.loadDependencies).to.have.been.called
+    })
+  })
+
+  describe('.styles', () => {
+    it('get combined from base and extension', async () => {
+      // given
+      const base: FocusNodeTemplate = function () {
+        return html``
+      }
+      base.styles = css`h1 { color: red }`
+
+      // when
+      const decorated = decorate((template: FocusNodeTemplate) => {
+        const decorated: FocusNodeTemplate = (c, a) => template(c, a)
+
+        decorated.styles = css`h2 { color: blue; }`
+
+        return decorated
+      })(base)
+      const styles = css`${decorated.styles as any}`.toString()
+
+      // then
+      expect(styles).to.contain('h1')
+      expect(styles).to.contain('h2')
+    })
+
+    it('reuses base styles if defined', async () => {
+      // given
+      const base: FocusNodeTemplate = function () {
+        return html``
+      }
+      base.styles = css`h1 { color: red }`
+
+      // when
+      const decorated = decorate((template: FocusNodeTemplate) => (c, a) => template(c, a))(base)
+      const styles = css`${decorated.styles as any}`.toString()
+
+      // then
+      expect(styles).to.contain('h1')
+    })
+  })
+})

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,6 +10,7 @@
     "packages/core/lib/property.ts",
     "packages/core/renderer.ts",
     "packages/hydra/components.ts",
+    "packages/wc/renderer/decorator.ts",
     "packages/wc/configure.ts",
     "packages/wc/index.ts",
     "packages/wc/NativeComponents.ts",


### PR DESCRIPTION
Without making that feature too specific, this PR introduces new properties of FocusNodeState which represent Node Shape logical constraints

Also, adds state actions to show/hide individual properties and an example for using `sh:xone` constraint to toggle groups of shapes