### PR TITLE
feat: updating with pointer

### DIFF
--- a/.changeset/strong-houses-shake.md
+++ b/.changeset/strong-houses-shake.md
@@ -1,0 +1,6 @@
+---
+"@hydrofoil/shaperone-core": patch
+"@hydrofoil/shaperone-wc": patch
+---
+
+The ability to update focus node values using graphs and not just individual terms

--- a/packages/core-tests/models/resources/effects/forms/clearValue.test.ts
+++ b/packages/core-tests/models/resources/effects/forms/clearValue.test.ts
@@ -42,4 +42,30 @@ describe('models/resources/effects/forms/clearValue', () => {
       $rdf.literal('15'),
     ])
   })
+
+  it('removes unique subgraph from graph', () => {
+    // given
+    const location = graph.blankNode().addOut(schema.streetAddress, 'Wisteria Lane')
+    const focusNode = graph.blankNode()
+      .addOut(schema.employmentUnit, (empl) => {
+        empl.addOut(schema.location, location)
+      })
+    const object = {
+      object: focusNode.out(schema.employmentUnit).toArray().shift(),
+    }
+    const property = propertyShape({
+      path: schema.employmentUnit,
+    })
+
+    // when
+    clearValue(store)({
+      form,
+      focusNode,
+      object,
+      property,
+    })
+
+    // then
+    expect(focusNode.dataset.size).to.eq(0)
+  })
 })

--- a/packages/core-tests/models/resources/effects/forms/removeObject.test.ts
+++ b/packages/core-tests/models/resources/effects/forms/removeObject.test.ts
@@ -7,6 +7,7 @@ import { testStore } from '@shaperone/testing/models/form'
 import removeObject from '@hydrofoil/shaperone-core/models/resources/effects/forms/removeObject'
 import { Store } from '@hydrofoil/shaperone-core/state'
 import { propertyShape } from '@shaperone/testing/util'
+import { unit } from '@tpluscode/rdf-ns-builders/strict'
 
 describe('models/resources/effects/forms/removeObject', () => {
   let store: Store
@@ -41,6 +42,32 @@ describe('models/resources/effects/forms/removeObject', () => {
     expect(focusNode.out(schema.age).terms).to.deep.contain.members([
       $rdf.literal('15'),
     ])
+  })
+
+  it("removes object's value from dataset, including subgraph", () => {
+    // given
+    const focusNode = graph.blankNode()
+      .addOut(schema.weight, (weight) => {
+        weight.addOut(schema.value, 2000)
+        weight.addOut(schema.unitCode, unit.KiloGM)
+      })
+    const object = {
+      object: focusNode.out(schema.weight).toArray().shift(),
+    }
+    const property = propertyShape({
+      path: schema.weight,
+    })
+
+    // when
+    removeObject(store)({
+      form,
+      focusNode,
+      object,
+      property,
+    })
+
+    // then
+    expect(focusNode.dataset.size).to.eq(0)
   })
 
   it('does nothing is object state had no value', () => {

--- a/packages/core-tests/models/resources/effects/forms/updateObject.test.ts
+++ b/packages/core-tests/models/resources/effects/forms/updateObject.test.ts
@@ -1,21 +1,23 @@
 import { describe, it } from 'mocha'
-import { AnyPointer } from 'clownface'
+import cf, { AnyContext, AnyPointer } from 'clownface'
 import $rdf from 'rdf-ext'
-import { schema } from '@tpluscode/rdf-ns-builders'
+import type DatasetExt from 'rdf-ext/lib/Dataset'
+import { schema, sh } from '@tpluscode/rdf-ns-builders'
 import { expect } from 'chai'
 import { testStore } from '@shaperone/testing/models/form'
 import updateObject from '@hydrofoil/shaperone-core/models/resources/effects/forms/updateObject'
 import { Store } from '@hydrofoil/shaperone-core/state'
 import { propertyShape } from '@shaperone/testing/util'
+import clownface from 'clownface'
 
 describe('models/resources/effects/forms/updateObject', () => {
   let store: Store
-  let graph: AnyPointer
+  let graph: AnyPointer<AnyContext, DatasetExt>
   let form: symbol
 
   beforeEach(() => {
     ({ form, store } = testStore());
-    ({ graph } = store.getState().resources.get(form)!)
+    ({ graph } = store.getState().resources.get(form) as any)
   })
 
   it('removes old value from graph', () => {
@@ -73,5 +75,109 @@ describe('models/resources/effects/forms/updateObject', () => {
       $rdf.literal('10'),
       $rdf.literal('15'),
     ])
+  })
+
+  it('removes blank node subgraphs not referenced any more', () => {
+    // given
+    const focusNode = graph
+      .namedNode('propertyShape')
+      .addOut(sh.path, (path) => {
+        path.addOut(sh.inversePath, (inverse) => {
+          inverse.addOut(sh.zeroOrOnePath, schema.name)
+        })
+      })
+    const object = {
+      object: focusNode.out(sh.path).toArray().shift(),
+    }
+    const shapesGraph = cf({ dataset: $rdf.dataset() })
+    const property = propertyShape(shapesGraph.blankNode(), {
+      path: sh.path,
+    })
+    const newValue = schema.name
+
+    // when
+    updateObject(store)({
+      form,
+      focusNode,
+      newValue,
+      property,
+      object,
+    })
+
+    // then
+    const expected = cf({ dataset: $rdf.dataset() }).namedNode('propertyShape')
+    expected.addOut(sh.path, schema.name)
+    expect(focusNode.dataset.toCanonical()).to.eq(expected.dataset.toCanonical())
+  })
+
+  it('replaces one subgraph with another', () => {
+    // given
+    const focusNode = graph
+      .namedNode('propertyShape')
+      .addOut(sh.path, (path) => {
+        path.addOut(sh.inversePath, (inverse) => {
+          inverse.addOut(sh.zeroOrOnePath, schema.name)
+        })
+      })
+    const object = {
+      object: focusNode.out(sh.path).toArray().shift(),
+    }
+    const shapesGraph = cf({ dataset: $rdf.dataset() })
+    const property = propertyShape(shapesGraph.blankNode(), {
+      path: sh.path,
+    })
+    const newValue = clownface({ dataset: $rdf.dataset() })
+      .blankNode()
+      .addList(sh.alternativePath, [schema.knows, schema.name])
+
+    // when
+    updateObject(store)({
+      form,
+      focusNode,
+      newValue,
+      property,
+      object,
+    })
+
+    // then
+    const expected = cf({ dataset: $rdf.dataset() }).namedNode('propertyShape')
+    expected.addOut(sh.path, path => path.addList(sh.alternativePath, [schema.knows, schema.name]))
+    expect(focusNode.dataset.toCanonical()).to.eq(expected.dataset.toCanonical())
+  })
+
+  it('does not remove subgraph if used multiple times in the data graph', () => {
+    // given
+    const location = graph.blankNode().addOut(schema.streetAddress, 'Wisteria Lane')
+    const focusNode = graph
+      .namedNode('fn')
+      .addOut(schema.employmentUnit, (empl) => {
+        empl.addOut(schema.location, location)
+      })
+      .addOut(schema.address, location)
+    const object = {
+      object: focusNode.out(schema.employmentUnit).toArray().shift(),
+    }
+    const shapesGraph = cf({ dataset: $rdf.dataset() })
+    const property = propertyShape(shapesGraph.blankNode(), {
+      path: schema.employmentUnit,
+    })
+    const newValue = $rdf.namedNode('external-id')
+
+    // when
+    updateObject(store)({
+      form,
+      focusNode,
+      newValue,
+      property,
+      object,
+    })
+
+    // then
+    const expected = cf({ dataset: $rdf.dataset() }).namedNode('fn')
+      .addOut(schema.address, (location) => {
+        location.addOut(schema.streetAddress, 'Wisteria Lane')
+      })
+      .addOut(schema.employmentUnit, $rdf.namedNode('external-id'))
+    expect(focusNode.dataset.toCanonical()).to.eq(expected.dataset.toCanonical())
   })
 })

--- a/packages/core/lib/graph.ts
+++ b/packages/core/lib/graph.ts
@@ -1,0 +1,40 @@
+import { GraphPointer } from 'clownface'
+import { BlankNode, Term } from 'rdf-js'
+
+export function deleteOrphanedSubgraphs(roots: GraphPointer[]): void {
+  const nextChildren =
+    roots.reduce<GraphPointer[]>((previous, child) => {
+      if (child.term.termType !== 'BlankNode') {
+        return previous
+      }
+      if (child.in().terms.length) {
+        return previous
+      }
+
+      const children = child.out().toArray()
+      child.deleteOut()
+      return [...previous, ...children]
+    }, [])
+
+  if (nextChildren.length) {
+    deleteOrphanedSubgraphs(nextChildren)
+  }
+}
+
+export function merge(focusNode: GraphPointer, newValue: GraphPointer): Term {
+  const prefix = focusNode.blankNode().value
+  function prefixBlank(term: BlankNode | Term) {
+    if (term.termType === 'BlankNode') {
+      return focusNode.blankNode(`${prefix}_${term.value}`).term
+    }
+
+    return term
+  }
+
+  for (const { subject, predicate, object } of newValue.dataset) {
+    focusNode.node(prefixBlank(subject))
+      .addOut(predicate, prefixBlank(object))
+  }
+
+  return prefixBlank(newValue.term)
+}

--- a/packages/core/models/components/index.ts
+++ b/packages/core/models/components/index.ts
@@ -6,6 +6,7 @@
 /* eslint-disable no-use-before-define */
 import { createModel } from '@captaincodeman/rdx'
 import type { NamedNode, Term } from 'rdf-js'
+import type { GraphPointer } from 'clownface'
 import reducers from './reducers'
 import type { FormSettings, PropertyObjectState, PropertyState } from '../forms/index'
 import type { Store } from '../../state'
@@ -38,7 +39,7 @@ export interface MultiEditorRenderParams<T extends ComponentInstance = Component
 }
 
 export interface SingleEditorActions {
-  update(newValue: Term | string): void
+  update(newValue: GraphPointer | Term | string): void
   focusOnObjectNode(): void
   clear(): void
   remove(): void

--- a/packages/core/models/forms/reducers/updateObject.ts
+++ b/packages/core/models/forms/reducers/updateObject.ts
@@ -14,7 +14,7 @@ export interface UpdateObjectParams extends BaseParams {
   focusNode: FocusNode
   property: PropertyShape
   object: PropertyObjectState
-  newValue: Term
+  newValue: Term | GraphPointer
 }
 
 export interface ReplaceObjectsParams extends BaseParams {

--- a/packages/core/models/resources/effects/forms/clearValue.ts
+++ b/packages/core/models/resources/effects/forms/clearValue.ts
@@ -2,6 +2,7 @@ import type { Store } from '../../../../state'
 import type { ClearValueParams } from '../../../forms/reducers/updateObject'
 import { notify } from '../../lib/notify'
 import { PropertyObjectState } from '../../../forms'
+import { deleteOrphanedSubgraphs } from '../../../../lib/graph'
 
 type Params = Omit<ClearValueParams, 'object'> & {
   object: Pick<PropertyObjectState, 'object'>
@@ -22,6 +23,7 @@ export default function (store: Store) {
     }
 
     state.graph.node(focusNode).deleteOut(pathProperty.id, removed.object)
+    deleteOrphanedSubgraphs(removed.object.toArray())
 
     notify({
       store,

--- a/packages/core/models/resources/effects/forms/removeObject.ts
+++ b/packages/core/models/resources/effects/forms/removeObject.ts
@@ -2,6 +2,7 @@ import type { Store } from '../../../../state'
 import * as removeObject from '../../../forms/reducers/removeObject'
 import { notify } from '../../lib/notify'
 import { PropertyObjectState } from '../../../forms'
+import { deleteOrphanedSubgraphs } from '../../../../lib/graph'
 
 type Params = Omit<removeObject.RemoveObjectParams, 'object'> & {
   object: Pick<PropertyObjectState, 'object'>
@@ -22,6 +23,7 @@ export default function (store: Store) {
     }
 
     state.graph.node(focusNode).deleteOut(pathProperty.id, removed.object)
+    deleteOrphanedSubgraphs(removed.object.toArray())
 
     notify({
       store,

--- a/packages/core/models/resources/effects/forms/setPropertyObjects.ts
+++ b/packages/core/models/resources/effects/forms/setPropertyObjects.ts
@@ -1,6 +1,7 @@
 import * as updateObject from '../../../forms/reducers/updateObject'
 import type { Store } from '../../../../state'
 import { notify } from '../../lib/notify'
+import { deleteOrphanedSubgraphs } from '../../../../lib/graph'
 
 type Params = Pick<updateObject.ReplaceObjectsParams, 'form' | 'focusNode' | 'property' | 'objects'>
 
@@ -10,9 +11,13 @@ export default function (store: Store) {
     const state = resources.get(form)
     const pathProperty = property.getPathProperty(true).id
 
+    const currentValues = state?.graph?.node(focusNode).out(pathProperty)
     state?.graph?.node(focusNode)
       .deleteOut(pathProperty)
       .addOut(pathProperty, objects)
+    if (currentValues) {
+      deleteOrphanedSubgraphs(currentValues.toArray())
+    }
 
     notify({
       store,

--- a/packages/testing/models/form.ts
+++ b/packages/testing/models/form.ts
@@ -4,7 +4,7 @@ import type { GraphPointer } from 'clownface'
 import { fromPointer } from '@rdfine/shacl/lib/PropertyShape'
 import { ResourceNode } from '@tpluscode/rdfine/RdfResource'
 import clownface from 'clownface'
-import { dataset } from '@rdf-esm/dataset'
+import $rdf from 'rdf-ext'
 import * as Form from '@hydrofoil/shaperone-core/models/forms'
 import { ResourceState } from '@hydrofoil/shaperone-core/models/resources'
 import { MultiEditor, SingleEditor } from '@hydrofoil/shaperone-core/models/editors'
@@ -121,7 +121,7 @@ export function testStore(): { form: symbol; store: Store } {
     validation: new Proxy({}, spyHandler),
   }
   const resourcesState: ResourceState = {
-    rootPointer: clownface({ dataset: dataset() }).blankNode(),
+    rootPointer: clownface({ dataset: $rdf.dataset() }).blankNode(),
     get graph() {
       return this.rootPointer.any()
     },
@@ -129,7 +129,7 @@ export function testStore(): { form: symbol; store: Store } {
   }
   const shapesState: ShapeState = {
     shapes: [],
-    shapesGraph: clownface({ dataset: dataset() }),
+    shapesGraph: clownface({ dataset: $rdf.dataset() }),
   }
   const state: State = {
     shapes: new Map([[form, shapesState]]),
@@ -139,7 +139,7 @@ export function testStore(): { form: symbol; store: Store } {
       allEditors: {},
       multiEditors: {},
       decorators: {},
-      metadata: clownface({ dataset: dataset() }),
+      metadata: clownface({ dataset: $rdf.dataset() }),
       matchMultiEditors: () => [],
       matchSingleEditors: () => [],
     },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,6 +12,7 @@
     "@tpluscode/rdf-ns-builders": "^1.0.0",
     "clownface": "^1.1.0",
     "deepmerge": "^4.2.2",
+    "rdf-ext": "^1",
     "sinon": "^9.2.1",
     "ts-sinon": "^2.0.1"
   },

--- a/packages/wc/renderer/editor.ts
+++ b/packages/wc/renderer/editor.ts
@@ -1,6 +1,7 @@
 import { PropertyRenderer, ObjectRenderer } from '@hydrofoil/shaperone-core/renderer'
 import { Term } from 'rdf-js'
 import { createTerm } from '@hydrofoil/shaperone-core/lib/property'
+import { GraphPointer } from 'clownface'
 
 export const renderMultiEditor: PropertyRenderer['renderMultiEditor'] = function () {
   const { dispatch, form, components, templates } = this.context
@@ -57,7 +58,7 @@ export const renderEditor: ObjectRenderer['renderEditor'] = function () {
   const { dispatch, form, state, components, templates } = this.context
   const { property, focusNode, object } = this
 
-  function update(termOrString: Term | string) {
+  function update(termOrString: GraphPointer | Term | string) {
     const newValue = typeof termOrString === 'string'
       ? createTerm(property, termOrString)
       : termOrString


### PR DESCRIPTION
This adds `GraphPointer` as possible argument of the `update` callback, making it possible to set deep subgraphs.

Additionally, updating and removing values will ensure that there are no blank node orphans