### PR TITLE
refactor(shoelace): tests failed to check hidden menu

### DIFF
--- a/.changeset/quick-pugs-travel.md
+++ b/.changeset/quick-pugs-travel.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-wc-shoelace": patch
+---
+
+Missing imports in `sh-sl-autocomplete`

--- a/packages/wc-shoelace/elements/sh-sl-autocomplete.ts
+++ b/packages/wc-shoelace/elements/sh-sl-autocomplete.ts
@@ -3,12 +3,17 @@ import { customElement, property, query } from 'lit/decorators.js'
 import type { GraphPointer } from 'clownface'
 import { SlInput } from '@shoelace-style/shoelace'
 import { stop } from '../lib/handlers.js'
+import '@shoelace-style/shoelace/dist/components/input/input.js'
+import '@shoelace-style/shoelace/dist/components/icon/icon.js'
+import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js'
+import '@shoelace-style/shoelace/dist/components/menu/menu.js'
+import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js'
 
 @customElement('sh-sl-autocomplete')
 export class ShSlAutocomplete extends LitElement {
   static get styles() {
     return css`
-      :host([empty]) sl-menu {
+      [hidden] {
         display: none;
       }
     `
@@ -20,7 +25,7 @@ export class ShSlAutocomplete extends LitElement {
   @property({ type: String })
     inputValue = ''
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean })
     empty = true
 
   @property({ type: Boolean })
@@ -37,6 +42,7 @@ export class ShSlAutocomplete extends LitElement {
         <sl-icon name="search" slot="suffix"></sl-icon>
       </sl-input>
       <sl-menu hoist .value=${this.selected?.value}
+               ?hidden="${this.empty}"
                placeholder="Missing data!"
                @sl-select=${this.dispatchItemSelected}>
         <slot @slotchange=${this.updateEmpty}></slot>

--- a/packages/wc-shoelace/test/elements/sh-sl-autocomplete.test.ts
+++ b/packages/wc-shoelace/test/elements/sh-sl-autocomplete.test.ts
@@ -11,11 +11,11 @@ describe('packages/wc-shoelace/elements/sh-sl-autocomplete', () => {
     expect(el.empty).to.be.true
   })
 
-  it('has empty attribute when empty', async () => {
+  it('hides menu when empty', async () => {
     // when
     const el = await fixture<ShSlAutocomplete>(html`<sh-sl-autocomplete></sh-sl-autocomplete>`)
 
     // then
-    expect(el).attr('empty').to.eq('')
+    expect(el.renderRoot.querySelector('sl-menu')).attr('hidden').to.eq('')
   })
 })


### PR DESCRIPTION
Refactor and fix a brittle test which failed #236 

Apparently it's a bad idea to have a reflected boolean attribute set to false