### PR TITLE
Shoelace select controls should be clearable

### DIFF
--- a/.changeset/famous-balloons-punch.md
+++ b/.changeset/famous-balloons-punch.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shaperone-wc-shoelace": patch
+---
+
+Relax shoelace dependency

--- a/.changeset/four-starfishes-smile.md
+++ b/.changeset/four-starfishes-smile.md
@@ -1,0 +1,7 @@
+---
+"@hydrofoil/shaperone-wc-shoelace": patch
+---
+
+Add "clearable" option to `dash:AutoCompleteEditor`, `dash:InstancesSelectEditor` and `dash:EnumSelectEditor`.
+
+To enable, annotate Property Shape with `sh1:clearable`

--- a/packages/wc-shoelace/README.md
+++ b/packages/wc-shoelace/README.md
@@ -4,6 +4,7 @@
 
 | Property          | Attribute          | Type                                             | Default |
 |-------------------|--------------------|--------------------------------------------------|---------|
+| `clearable`       | `clearable`        | `boolean`                                        | false   |
 | `debounceTimeout` | `debounce-timeout` | `number`                                         | 350     |
 | `empty`           | `empty`            | `boolean`                                        | true    |
 | `hoist`           | `hoist`            | `boolean`                                        | true    |
@@ -16,6 +17,7 @@
 
 | Method                 | Type                          |
 |------------------------|-------------------------------|
+| `cleared`              | `(e: Event): void`            |
 | `dispatchItemSelected` | `(e: CustomEvent<any>): void` |
 | `dispatchSearch`       | `(): void`                    |
 | `updateEmpty`          | `(e: Event): void`            |
@@ -24,6 +26,7 @@
 
 | Event          | Type                              |
 |----------------|-----------------------------------|
+| `cleared`      |                                   |
 | `itemSelected` | `CustomEvent<{ value: any; }>`    |
 | `search`       | `CustomEvent<{ value: string; }>` |
 

--- a/packages/wc-shoelace/components/autocomplete.ts
+++ b/packages/wc-shoelace/components/autocomplete.ts
@@ -8,6 +8,7 @@ import isGraphPointer from 'is-graph-pointer'
 import { NamedNode } from 'rdf-js'
 import { SingleEditorRenderParams } from '@hydrofoil/shaperone-core/models/components'
 import type { GraphPointer } from 'clownface'
+import sh1 from '@hydrofoil/shaperone-core/ns'
 import { renderItem } from '../lib/components.js'
 import { settings } from '../settings.js'
 
@@ -33,7 +34,7 @@ export const autocomplete: Lazy<AutoCompleteEditor> & Options = {
   async lazyRender() {
     await import('../elements/sh-sl-autocomplete.js')
 
-    return (params, { update }) => {
+    return (params, { update, clear }) => {
       const { value, property } = params
       const pointers = value.componentState.instances || []
       const freetextQuery = value.componentState.freetextQuery || ''
@@ -62,11 +63,14 @@ export const autocomplete: Lazy<AutoCompleteEditor> & Options = {
         nodeValue = nodeUrl.hash || nodeUrl.pathname
       }
       const fallback = nodeValue || freetextQuery
+      const clearable = property.shape.getBoolean(sh1.clearable)
 
       return html`
         <sh-sl-autocomplete .selected=${selected}
                             .inputValue=${localizedLabel(selected, { property: autocomplete.labelProperties, fallback })}
                             @search=${search}
+                            .clearable="${clearable}"
+                            @cleared="${clear}"
                             @itemSelected=${itemSelected}
                             .readonly="${property.shape.readOnly || false}"
                             .hoist="${settings.hoist}"

--- a/packages/wc-shoelace/components/enumSelect.ts
+++ b/packages/wc-shoelace/components/enumSelect.ts
@@ -6,10 +6,10 @@ export const enumSelect: Lazy<Core.EnumSelectEditor> = {
   async lazyRender() {
     const { select } = await import('./select.js')
 
-    return ({ value, componentState, property }, { update }) => {
+    return ({ value, componentState, property }, actions) => {
       const pointers = componentState.choices || []
 
-      return select({ value, pointers, update, property })
+      return select({ value, pointers, actions, property })
     }
   },
 }

--- a/packages/wc-shoelace/components/instancesSelect.ts
+++ b/packages/wc-shoelace/components/instancesSelect.ts
@@ -6,10 +6,10 @@ export const instancesSelect: Lazy<Core.InstancesSelectEditor> = {
   async lazyRender() {
     const { select } = await import('./select.js')
 
-    return ({ value, property, componentState }, { update }) => {
+    return ({ value, property, componentState }, actions) => {
       const pointers = componentState.instances || []
 
-      return select({ property, value, pointers, update })
+      return select({ property, value, pointers, actions })
     }
   },
 }

--- a/packages/wc-shoelace/components/select.ts
+++ b/packages/wc-shoelace/components/select.ts
@@ -1,4 +1,5 @@
 import { SingleEditorActions } from '@hydrofoil/shaperone-core/models/components'
+import sh1 from '@hydrofoil/shaperone-core/ns.js'
 import { html } from 'lit'
 import '@shoelace-style/shoelace/dist/components/select/select.js'
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js'
@@ -13,11 +14,13 @@ import { settings } from '../settings.js'
 interface Parameters {
   value: PropertyObjectState
   pointers: GraphPointer[]
-  update: SingleEditorActions['update']
+  actions: Pick<SingleEditorActions, 'update' | 'clear'>
   property: PropertyState
 }
 
-export function select({ update, value, pointers, property }: Parameters) {
+export function select({ actions: { update, clear }, value, pointers, property }: Parameters) {
+  const clearable = property.shape.getBoolean(sh1.clearable)
+
   function onChange(e: Event) {
     const target = e.target as SlSelect
     const selected = pointers.find(({ value }) => value === target.value)
@@ -25,7 +28,13 @@ export function select({ update, value, pointers, property }: Parameters) {
     if (selected) { update(selected.term) }
   }
 
-  return html`<sl-select .disabled="${property.shape.readOnly || false}" ?hoist="${settings.hoist}" .value=${value.object?.value || ''} @sl-change=${onChange} @sl-hide=${stop}>
+  return html`<sl-select ?clearable="${clearable}"
+                         .disabled="${property.shape.readOnly || false}"
+                         ?hoist="${settings.hoist}"
+                         .value=${value.object?.value || ''}
+                         @sl-clear="${clear}"
+                         @sl-change=${onChange}
+                         @sl-hide=${stop}>
     ${repeat(pointers || [], renderItem)}
   </sl-select>`
 }

--- a/packages/wc-shoelace/custom-elements.json
+++ b/packages/wc-shoelace/custom-elements.json
@@ -30,6 +30,11 @@
           "default": "false"
         },
         {
+          "name": "clearable",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
           "name": "debounce-timeout",
           "type": "number",
           "default": "350"
@@ -70,6 +75,12 @@
           "default": "false"
         },
         {
+          "name": "clearable",
+          "attribute": "clearable",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
           "name": "debounceTimeout",
           "attribute": "debounce-timeout",
           "type": "number",
@@ -82,6 +93,9 @@
         }
       ],
       "events": [
+        {
+          "name": "cleared"
+        },
         {
           "name": "search"
         },

--- a/packages/wc-shoelace/elements/sh-sl-autocomplete.ts
+++ b/packages/wc-shoelace/elements/sh-sl-autocomplete.ts
@@ -6,6 +6,7 @@ import debounce from 'p-debounce'
 import { stop } from '../lib/handlers.js'
 import '@shoelace-style/shoelace/dist/components/input/input.js'
 import '@shoelace-style/shoelace/dist/components/icon/icon.js'
+import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js'
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js'
 import '@shoelace-style/shoelace/dist/components/menu/menu.js'
 import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js'
@@ -56,6 +57,9 @@ export class ShSlAutocomplete extends LitElement {
   @property({ type: Boolean })
   public readonly = false
 
+  @property({ type: Boolean })
+  public clearable = false
+
   @property({ type: Number, attribute: 'debounce-timeout' })
   public debounceTimeout = 350
 
@@ -78,6 +82,11 @@ export class ShSlAutocomplete extends LitElement {
                 @sl-focus="${() => { this._hasFocus = true }}"
                 @sl-blur="${() => { this._hasFocus = false }}"
                 @sl-input="${debounce(this.dispatchSearch, this.debounceTimeout)}">
+        <sl-icon-button id="clear"
+                        name="x-circle-fill"
+                        slot="suffix"
+                        ?hidden="${!this.selected || !this.clearable}"
+                        @click="${this.cleared}"></sl-icon-button>
         <sl-icon name="${this.loading ? 'arrow-repeat' : 'search'}" slot="suffix"></sl-icon>
       </sl-input>
       <sl-menu hoist .value=${this.selected?.value}
@@ -98,6 +107,11 @@ export class ShSlAutocomplete extends LitElement {
         this._menu.show()
       }
     }
+  }
+
+  cleared(e: Event) {
+    e.stopPropagation()
+    this.dispatchEvent(new Event('cleared'))
   }
 
   updateEmpty(e: Event) {

--- a/packages/wc-shoelace/package.json
+++ b/packages/wc-shoelace/package.json
@@ -25,7 +25,7 @@
     "@rdfine/shacl": "^0.8.7",
     "@rdfjs/data-model": "^2",
     "@rdfjs-elements/lit-helpers": "^0.3.5",
-    "@shoelace-style/shoelace": "^2.0.0-beta.77",
+    "@shoelace-style/shoelace": ">=2.0.0-beta.77 < 3",
     "@tpluscode/rdf-ns-builders": "^2",
     "is-graph-pointer": "^1.2.2",
     "lit": "^2",

--- a/packages/wc-shoelace/test/components/autocomplete.test.ts
+++ b/packages/wc-shoelace/test/components/autocomplete.test.ts
@@ -4,6 +4,8 @@ import cf from 'clownface'
 import $rdf from '@rdf-esm/dataset'
 import { editorTestParams } from '@shaperone/testing'
 import { AutoComplete } from '@hydrofoil/shaperone-core/components'
+import { SlIconButton } from '@shoelace-style/shoelace'
+import sh1 from '@hydrofoil/shaperone-core/ns'
 import { autocomplete, AutoCompleteEditor } from '../../components/autocomplete.js'
 import { ShSlAutocomplete } from '../../elements/sh-sl-autocomplete'
 
@@ -73,5 +75,56 @@ describe('wc-shoelace/components/autocomplete', () => {
 
     // then
     expect(result).to.have.attr('loading')
+  })
+
+  context('property sh1:clearable true', () => {
+    it('clears selection when icon clicked', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const { params, actions } = editorTestParams<AutoComplete>({
+        property: {
+          [sh1.clearable.value]: true,
+        },
+        componentState: {
+          instances: [
+            graph.literal('A'),
+            graph.literal('B'),
+            graph.literal('C'),
+          ],
+        },
+        object: graph.literal('B'),
+      })
+
+      // when
+      const editor = await fixture<ShSlAutocomplete>(component.render(params, actions))
+      editor.renderRoot.querySelector<SlIconButton>('#clear')?.click()
+
+      // then
+      expect(actions.clear).to.have.been.calledOnce
+      expect(editor.renderRoot.querySelector('sl-dropdown')).to.have.property('open', false)
+    })
+
+    it('does not show clear button when there is no value', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const { params, actions } = editorTestParams<AutoComplete>({
+        property: {
+          [sh1.clearable.value]: true,
+        },
+        componentState: {
+          instances: [
+            graph.literal('A'),
+          ],
+        },
+        object: undefined,
+      })
+
+      // when
+      const editor = await fixture<ShSlAutocomplete>(component.render(params, actions))
+      const clearButton = editor.renderRoot.querySelector('#clear')
+
+      // then
+      expect(getComputedStyle(clearButton!).display).to.eq('none')
+    })
   })
 })

--- a/packages/wc-shoelace/test/components/enumSelect.test.ts
+++ b/packages/wc-shoelace/test/components/enumSelect.test.ts
@@ -1,9 +1,10 @@
 import cf from 'clownface'
 import $rdf from '@rdf-esm/dataset'
 import { editorTestParams } from '@shaperone/testing'
-import { expect, fixture } from '@open-wc/testing'
+import { expect, fixture, nextFrame } from '@open-wc/testing'
 import { SlSelect } from '@shoelace-style/shoelace/dist/shoelace'
-import { EnumSelect, EnumSelectEditor } from '@hydrofoil/shaperone-core/lib/components/enumSelect'
+import { EnumSelect } from '@hydrofoil/shaperone-core/lib/components/enumSelect'
+import sh1 from '@hydrofoil/shaperone-core/ns.js'
 import { enumSelect } from '../../components/enumSelect'
 
 describe('wc-shoelace/components/enumSelect', () => {
@@ -15,10 +16,14 @@ describe('wc-shoelace/components/enumSelect', () => {
       render: await enumSelect.lazyRender(),
     }
   })
+
   it('is disabled when dash:readOnly true', async () => {
     // given
     const graph = cf({ dataset: $rdf.dataset() })
-    const { params, actions } = editorTestParams<EnumSelectEditor>({
+    const {
+      params,
+      actions,
+    } = editorTestParams<EnumSelect>({
       property: {
         readOnly: true,
       },
@@ -30,5 +35,57 @@ describe('wc-shoelace/components/enumSelect', () => {
 
     // then
     expect(result.disabled).to.be.true
+  })
+
+  context('property sh1:clearable true', () => {
+    it('makes select clearable', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const {
+        params,
+        actions,
+      } = editorTestParams<EnumSelect>({
+        property: {
+          readOnly: true,
+          [sh1.clearable.value]: true,
+        },
+        object: graph.literal(''),
+      })
+
+      // when
+      const result = await fixture<SlSelect>(component.render(params, actions))
+
+      // then
+      expect(result.clearable).to.be.true
+    })
+
+    it('clears value when cleared', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const {
+        params,
+        actions,
+      } = editorTestParams<EnumSelect>({
+        property: {
+          [sh1.clearable.value]: true,
+        },
+        object: graph.literal('B'),
+        componentState: {
+          choices: [
+            graph.literal('A'),
+            graph.literal('B'),
+            graph.literal('C'),
+          ],
+        },
+      })
+
+      // when
+      const result = await fixture<SlSelect>(component.render(params, actions))
+      result.renderRoot.querySelector<HTMLButtonElement>('.select__clear')?.click()
+      await nextFrame()
+
+      // then
+      expect(actions.clear).to.have.been.called
+    })
   })
 })

--- a/packages/wc-shoelace/test/components/instancesSelect.test.ts
+++ b/packages/wc-shoelace/test/components/instancesSelect.test.ts
@@ -3,7 +3,8 @@ import $rdf from '@rdf-esm/dataset'
 import { editorTestParams } from '@shaperone/testing'
 import { expect, fixture } from '@open-wc/testing'
 import { SlSelect } from '@shoelace-style/shoelace/dist/shoelace'
-import { InstancesSelect, InstancesSelectEditor } from '@hydrofoil/shaperone-core/lib/components/instancesSelect'
+import { InstancesSelect } from '@hydrofoil/shaperone-core/lib/components/instancesSelect'
+import sh1 from '@hydrofoil/shaperone-core/ns'
 import { instancesSelect } from '../../components/instancesSelect'
 
 describe('wc-shoelace/components/instancesSelect', () => {
@@ -15,10 +16,11 @@ describe('wc-shoelace/components/instancesSelect', () => {
       render: await instancesSelect.lazyRender(),
     }
   })
+
   it('is disabled when dash:readOnly true', async () => {
     // given
     const graph = cf({ dataset: $rdf.dataset() })
-    const { params, actions } = editorTestParams<InstancesSelectEditor>({
+    const { params, actions } = editorTestParams<InstancesSelect>({
       property: {
         readOnly: true,
       },
@@ -30,5 +32,49 @@ describe('wc-shoelace/components/instancesSelect', () => {
 
     // then
     expect(result.disabled).to.be.true
+  })
+
+  context('property sh1:clearable true', () => {
+    it('makes select clearable', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const { params, actions } = editorTestParams<InstancesSelect>({
+        property: {
+          [sh1.clearable.value]: true,
+        },
+        object: graph.namedNode(''),
+      })
+
+      // when
+      const result = await fixture<SlSelect>(component.render(params, actions))
+
+      // then
+      expect(result.clearable).to.be.true
+    })
+
+    it('clears value when cleared', async () => {
+      // given
+      const graph = cf({ dataset: $rdf.dataset() })
+      const { params, actions } = editorTestParams<InstancesSelect>({
+        property: {
+          [sh1.clearable.value]: true,
+        },
+        object: graph.namedNode('A'),
+        componentState: {
+          choices: [
+            graph.namedNode('A'),
+            graph.namedNode('B'),
+            graph.namedNode('C'),
+          ],
+        },
+      })
+
+      // when
+      const result = await fixture<SlSelect>(component.render(params, actions))
+      result.renderRoot.querySelector<HTMLButtonElement>('.select__clear')?.click()
+
+      // then
+      expect(actions.clear).to.have.been.called
+    })
   })
 })

--- a/packages/wc-shoelace/test/elements/sh-sl-autocomplete.test.ts
+++ b/packages/wc-shoelace/test/elements/sh-sl-autocomplete.test.ts
@@ -1,4 +1,5 @@
 import { html, expect, fixture } from '@open-wc/testing'
+import { namedNode } from '@shaperone/testing/nodeFactory'
 import '../../elements/sh-sl-autocomplete.js'
 import type { ShSlAutocomplete } from '../../elements/sh-sl-autocomplete'
 
@@ -23,7 +24,7 @@ describe('wc-shoelace/elements/sh-sl-autocomplete', () => {
     // when
     const el = await fixture<ShSlAutocomplete>(html`<sh-sl-autocomplete readonly></sh-sl-autocomplete>`)
 
-    // expect
+    // then
     expect(el.renderRoot.querySelector('sl-dropdown')?.disabled).to.be.true
   })
 
@@ -31,7 +32,28 @@ describe('wc-shoelace/elements/sh-sl-autocomplete', () => {
     // when
     const el = await fixture<ShSlAutocomplete>(html`<sh-sl-autocomplete loading></sh-sl-autocomplete>`)
 
-    // expect
+    // then
     expect(el.renderRoot.querySelector('sl-input sl-icon')).to.have.style('animation-name', 'spin')
+  })
+
+  it('shows clear button when [clearable]', async () => {
+    // given
+    const value = namedNode('test')
+
+    // when
+    const el = await fixture<ShSlAutocomplete>(html`<sh-sl-autocomplete clearable .selected="${value}"></sh-sl-autocomplete>`)
+    const clearButton = el.renderRoot.querySelector('#clear')
+
+    // then
+    expect(getComputedStyle(clearButton!).display).not.to.eq('none')
+  })
+
+  it('does not show clear button when :not([clearable])', async () => {
+    // when
+    const el = await fixture<ShSlAutocomplete>(html`<sh-sl-autocomplete></sh-sl-autocomplete>`)
+    const clearButton = el.renderRoot.querySelector('#clear')
+
+    // then
+    expect(getComputedStyle(clearButton!).display).to.eq('none')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,17 +1171,17 @@
   dependencies:
     "@types/chai" "^4.2.12"
 
-"@floating-ui/core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
-  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+"@floating-ui/core@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.2.tgz#d06a66d3ad8214186eda2432ac8b8d81868a571f"
+  integrity sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==
 
-"@floating-ui/dom@^1.0.0":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.4.tgz#cc0f2a03db7193b1b932b90d09c5c81235682a60"
-  integrity sha512-maYJRv+sAXTy4K9mzdv0JPyNW5YPVHrqtY90tEdI6XNpuLOP26Ci2pfwPsKBA/Wh4Z3FX5sUrtUFTdMYj9v+ug==
+"@floating-ui/dom@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.7.tgz#9e8e6615ce03e5ebc6a4ae879640a199a366f86d"
+  integrity sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==
   dependencies:
-    "@floating-ui/core" "^1.0.1"
+    "@floating-ui/core" "^1.0.2"
 
 "@fortawesome/fontawesome-common-types@^0.2.32":
   version "0.2.32"
@@ -1405,7 +1405,7 @@
   dependencies:
     vary "^1.1.2"
 
-"@lit-labs/react@^1.0.7":
+"@lit-labs/react@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.1.0.tgz#665cf27cc83c5d0c6782ead5b906bd250619442b"
   integrity sha512-uvdOtzACm1WzTySpKnqXth62iPL+4yDow7cSZH7m7jHbDr+tZVXn44DJ5IoJuMjEevORRe57lNrOywFW6d4Fyg==
@@ -2605,22 +2605,22 @@
   resolved "https://registry.yarnpkg.com/@shoelace-style/animations/-/animations-1.1.0.tgz#17539abafd6dcbf2a79e089e1593175e9f7835b5"
   integrity sha512-Be+cahtZyI2dPKRm8EZSx3YJQ+jLvEcn3xzRP7tM4tqBnvd/eW/64Xh0iOf0t2w5P8iJKfdBbpVNE9naCaOf2g==
 
-"@shoelace-style/localize@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@shoelace-style/localize/-/localize-3.0.1.tgz#a6eda8ae29ac32fb59df50f3db14652a23f492c9"
-  integrity sha512-nmv1syJ3ormbGq29GsuxGRK6BFq7Jhx+kVFyuuozz0Pckkvk1SGk2vpZZcdnj2vRZCETvlVB7KYgakUwgGmn+A==
+"@shoelace-style/localize@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/localize/-/localize-3.0.3.tgz#d69e1f0e547799ecd5deb5e6ed9c8c78b4d01eb6"
+  integrity sha512-BVYDsMTpSCjvC8akhTkcnl4WIgAv7AnRq8fSuNhdGDLjkpmN1ARdAXic5luAozoMVjft85ocOmEdT8z7MbXdmQ==
 
-"@shoelace-style/shoelace@^2.0.0-beta.77", "@shoelace-style/shoelace@^2.0.0-beta.78":
-  version "2.0.0-beta.83"
-  resolved "https://registry.yarnpkg.com/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.83.tgz#9ea923e969a2cfc7c0b8ad46c81822b04a1c1520"
-  integrity sha512-dHVBtapuqxSRu3klBZhf9/LtEtircaLLnDajNbhuiBiY7PVCxjjf/9Kyd/S/BpbhKwMICqJr+PaKoCTd2iWDJA==
+"@shoelace-style/shoelace@>=2.0.0-beta.77 < 3", "@shoelace-style/shoelace@^2.0.0-beta.78":
+  version "2.0.0-beta.85"
+  resolved "https://registry.yarnpkg.com/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.85.tgz#57156a41aa366b9a8241cc47b127d2b663555e8a"
+  integrity sha512-Kq4BUEtB2tNlBPx97qM1/UQDBFYINMnlL4qNAHs0cCZF6q4J6U1NHot8TzWO83G4ufPHzNtjz9gaJLgzGWnNOA==
   dependencies:
-    "@floating-ui/dom" "^1.0.0"
-    "@lit-labs/react" "^1.0.7"
+    "@floating-ui/dom" "^1.0.7"
+    "@lit-labs/react" "^1.1.0"
     "@shoelace-style/animations" "^1.1.0"
-    "@shoelace-style/localize" "^3.0.1"
+    "@shoelace-style/localize" "^3.0.3"
     color "4.2"
-    lit "^2.2.8"
+    lit "^2.4.1"
     qr-creator "^1.0.0"
 
 "@sindresorhus/is@^0.14.0":
@@ -9390,7 +9390,7 @@ lit-html@^2.0.0, lit-html@^2.2.0, lit-html@^2.4.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@^2, lit@^2.0.0, lit@^2.2.8:
+lit@^2, lit@^2.0.0, lit@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lit/-/lit-2.4.1.tgz#21251ac14eb1ec8ca7cd15c9ac3564359809f7b5"
   integrity sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==


### PR DESCRIPTION
This will not be enabled by default, but only when a Property Shape is explicitly annotated

```turtle
[
  sh:property [
    dash:editor dash:InstancesSelectEditor ;
    sh1:clearable true ;
  ] ;
] .
```